### PR TITLE
clean up error handling

### DIFF
--- a/src/app/search/SearchPage.jsx
+++ b/src/app/search/SearchPage.jsx
@@ -8,6 +8,7 @@ import StreamValue from '../store/StreamValue.js'
 import NavBar from '../common/NavBar.jsx'
 import {SEARCH_NAV} from '../store/Navigation.js'
 import {isCustomList} from '../store/CustomList.js'
+import {getAndLogErrorMessage} from '../store/AjaxErrorMessage.js'
 
 
 const ITEMS_PER_PAGE = 20;
@@ -86,7 +87,8 @@ class SearchPage extends React.Component {
             }, this.searchFirstPage);
           }.bind(this),
           error: function(xhr, status, err) {
-            console.error(this.url, status, err.toString());
+              let message = getAndLogErrorMessage('fetching genome metadata', xhr, status, err);
+              alert(message);
           }.bind(this)
         });
       }

--- a/src/app/store/AjaxErrorMessage.js
+++ b/src/app/store/AjaxErrorMessage.js
@@ -1,0 +1,9 @@
+export function getAndLogErrorMessage(activityStr, xhr, status, err) {
+    var errorMsg = err;
+    if (xhr.responseJSON) {
+        errorMsg = xhr.responseJSON.message;
+    }
+    let message = 'Error ' + activityStr + ': ' + errorMsg;
+    console.log(message);
+    return message;
+}

--- a/src/app/store/CustomFile.js
+++ b/src/app/store/CustomFile.js
@@ -1,3 +1,5 @@
+import {getAndLogErrorMessage} from './AjaxErrorMessage.js'
+
 const ENDPOINT = '/api/v1/custom_list';
 const KEY_NAME = 'key';
 const MAX_FILE_SIZE = 20 * 1024 * 1024;
@@ -51,10 +53,8 @@ class CustomFile {
                 onData(data[KEY_NAME]);
             }.bind(this),
             error: function (xhr, status, err) {
-                if (xhr.responseJSON) {
-                    err = xhr.responseJSON.message;
-                }
-                onError('Error uploading custom file: ' + err);
+                let message = getAndLogErrorMessage('uploading custom file', xhr, status, err);
+                onError(message);
             }.bind(this)
         });
     }

--- a/src/app/store/DataSourceData.js
+++ b/src/app/store/DataSourceData.js
@@ -1,3 +1,5 @@
+import {getAndLogErrorMessage} from './AjaxErrorMessage.js'
+
 const ENDPOINT = '/api/v1/datasources';
 const PREDICTION_NAME = 'prediction';
 const GENELIST_NAME = 'genelist';
@@ -17,8 +19,8 @@ class DataSourceData {
                 );
             }.bind(this),
             error: function (xhr, status, err) {
-                console.error(this.props.url, status, err.toString());
-                onError('Error fetching datasources data' + err.toString());
+                var errorMessage = getAndLogErrorMessage('fetching datasource data', xhr, status, err);
+                onError(errorMessage);
             }.bind(this)
         });
     }

--- a/src/app/store/DnaSequences.js
+++ b/src/app/store/DnaSequences.js
@@ -1,3 +1,4 @@
+import {getAndLogErrorMessage} from './AjaxErrorMessage.js'
 const ENDPOINT = '/api/v1/genomes/';
 
 class DnaSequences {
@@ -31,8 +32,8 @@ class DnaSequences {
                 onData(data.sequences);
             }.bind(this),
             error: function (xhr, status, err) {
-                onError('Error fetching dna sequences' + err);
-                console.log('Error fetching dna sequences' + err);
+                let message = getAndLogErrorMessage('fetching dna sequences', xhr, status, err);
+                onError(message);
             }.bind(this)
         });
     }

--- a/src/app/store/URLBuilder.js
+++ b/src/app/store/URLBuilder.js
@@ -1,3 +1,5 @@
+import {getAndLogErrorMessage} from './AjaxErrorMessage.js'
+
 class URLBuilder {
     constructor(fetchMethod) {
         this.fetchMethod = fetchMethod;
@@ -44,10 +46,7 @@ class URLBuilder {
                 onData(data);
             },
             error: function (xhr, status, err) {
-                var errorMessage = err;
-                if (xhr.responseJSON) {
-                    errorMessage = xhr.responseJSON.message;
-                }
+                var errorMessage = getAndLogErrorMessage('fetching data', xhr, status, err);
                 onError({
                     url: url,
                     status: status,

--- a/webserver.py
+++ b/webserver.py
@@ -37,7 +37,7 @@ def create_db_connection(config):
                                 ' user=' + config.user +
                                 ' password=' + config.password)
     except:
-        raise ValueError("Unable to connect to database.")
+        raise ValueError("Unable to connect to the database.")
 
 
 @app.teardown_appcontext
@@ -117,8 +117,11 @@ def prediction_search(genome):
 def get_sequences(genome):
     json_data = request.get_json()
     ranges = json_data['ranges']
-    sequences = lookup_dna_sequence(g_config, genome, ranges)
-    return make_json_response({'sequences': sequences})
+    try:
+        sequences = lookup_dna_sequence(g_config, genome, ranges)
+        return make_json_response({'sequences': sequences})
+    except FileNotFoundError:
+        raise ValueError("Missing file for {}.".format(genome))
 
 
 @app.errorhandler(ValueError)


### PR DESCRIPTION
Started seeing errors 'Failed to load resource: The network connection was lost.' in console on an older iPad safari. However the error message was blank which caused 'No results found' to print.
I made changes so it will print the empty error message. Looks like there may be apache/nginx settings related to keepalive that might help. Changing keepalive in gunicorn didn't.
