### PR TITLE
Increase sort by max guess to handle larger data better

### DIFF
--- a/src/app/store/PredictionsStore.js
+++ b/src/app/store/PredictionsStore.js
@@ -118,7 +118,7 @@ class PredictionsStore {
         urlBuilder.appendParam('maxPredictionSort', searchSettings.maxPredictionSort);
 
         if (searchSettings.maxPredictionSort) {
-            urlBuilder.appendParam('maxPredictionGuess', '0.4');
+            urlBuilder.appendParam('maxPredictionGuess', '0.7');
         }
         if (page && perPage) {
             urlBuilder.appendParam('page', page);


### PR DESCRIPTION
Sort by max for large data sets is too slow so increasing initial guess.
If enough rows are not found using guess query us rerun without guess(which usually takes longer).
