### PR TITLE
UCSC ftp fix

### DIFF
--- a/pred/load/download.py
+++ b/pred/load/download.py
@@ -146,7 +146,6 @@ class GenomeDownloader(object):
         if not os.path.exists(self.local_dir):
             os.mkdir(self.local_dir)
         ftp = FTP(self.ftp_host, 'anonymous', 'gcb-contact@duke.edu')
-        ftp.login()
         ftp.cwd(self.get_ftp_dir())
         with open(out_filename, 'wb') as outfile:
             ftp.retrbinary("RETR " + filename, outfile.write)

--- a/pred/load/download.py
+++ b/pred/load/download.py
@@ -145,7 +145,7 @@ class GenomeDownloader(object):
         self.update_progress('Downloading: ' + filename)
         if not os.path.exists(self.local_dir):
             os.mkdir(self.local_dir)
-        ftp = FTP(self.ftp_host)
+        ftp = FTP(self.ftp_host, 'anonymous', 'gcb-contact@duke.edu')
         ftp.login()
         ftp.cwd(self.get_ftp_dir())
         with open(out_filename, 'wb') as outfile:


### PR DESCRIPTION
UCSC now requires an email in password field for FTP.
