### PR TITLE
Predictions worker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.env_sample
+++ b/.env_sample
@@ -12,3 +12,9 @@ POSTGRES_USER=pred_user
 #database password for web and db
 DB_PASS=pred_password
 POSTGRES_PASSWORD=pred_password
+
+#predictions worker
+OUTPUT_DIR=/pred_data/work
+BASE_URL=http://web/api/v1
+MODEL_FILES_DIR=/pred_data/models
+CONFIG_FILE=/pred_data/models/tracks.yaml

--- a/.env_sample
+++ b/.env_sample
@@ -1,14 +1,14 @@
 #settings for service 'web' in docker-compose.yml
-DB_HOST_ENV="db"
+DB_HOST=db
 
 #database name for web and db
-DB_NAME_ENV="pred"
-POSTGRES_DB="pred"
+DB_NAME=pred
+POSTGRES_DB=pred
 
 #database user for web and db
-DB_USER_ENV="pred_user"
-POSTGRES_USER="pred_user"
+DB_USER=pred_user
+POSTGRES_USER=pred_user
 
 #database password for web and db
-DB_PASS_ENV="pred_password"
-POSTGRES_PASSWORD="pred_password"
+DB_PASS=pred_password
+POSTGRES_PASSWORD=pred_password

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .eggs
 node_modules
 env/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
 FROM python:2.7.11
-EXPOSE 8000
+EXPOSE 80
 ENV MYDIR /tfdnapredictions
 RUN apt-get update
 RUN apt-get install nodejs -y
 RUN apt-get install npm -y
 RUN ln -s /usr/bin/nodejs /usr/bin/node
-RUN npm install -g npm
 ADD . $MYDIR
 WORKDIR ${MYDIR}
+RUN npm install -g npm
+RUN npm install --dev
+RUN npm install webpack -g
+RUN webpack
 RUN npm install -g
-RUN ["chmod", "777", "/tfdnapredictions/clone_and_run.sh"]
 ADD http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/bigBedToBed /usr/local/bin/bigBedToBed
 RUN ["chmod", "777", "/usr/local/bin/bigBedToBed"]
 RUN ["pip", "install", "-r", "requirements.txt"]
 RUN ["pip", "install", "gunicorn"]
-CMD ["./clone_and_run.sh"]
+CMD ["gunicorn", "--bind", "0.0.0.0:80", "--timeout", "180", "--log-level=debug", "webserver:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,26 @@ RUN apt-get update
 RUN apt-get install nodejs -y
 RUN apt-get install npm -y
 RUN ln -s /usr/bin/nodejs /usr/bin/node
-ADD . $MYDIR
-WORKDIR ${MYDIR}
-RUN npm install -g npm
-RUN npm install --dev
-RUN npm install webpack -g
-RUN webpack
-RUN npm install -g
+
+# Install bigBedToBed
 ADD http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/bigBedToBed /usr/local/bin/bigBedToBed
 RUN ["chmod", "777", "/usr/local/bin/bigBedToBed"]
-RUN ["pip", "install", "-r", "requirements.txt"]
+
+# Install global dependencies
+RUN npm install -g npm
+RUN npm install webpack -g
 RUN ["pip", "install", "gunicorn"]
+
+# Install project dependencies - dependency files are added independently so that
+# changes to application source code don't trigger a cache invalidation at this step
+WORKDIR ${MYDIR}
+ADD package.json ${MYDIR}/
+RUN npm install -g
+ADD requirements.txt ${MYDIR}/
+RUN ["pip", "install", "-r", "requirements.txt"]
+RUN npm install --dev
+
+# Now add the rest of the application source and run webpack
+ADD . ${MYDIR}
+RUN webpack
 CMD ["gunicorn", "--bind", "0.0.0.0:80", "--timeout", "180", "--log-level=debug", "webserver:app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 services:
   web:
     image: jbradley/tfpred
+    build: .
     env_file: .env
     ports:
       - "80:80"
@@ -18,3 +19,13 @@ services:
     depends_on:
       - db
     command: python vacuum.py 2880
+  predictions_worker:
+    image: dukegcb/predict-tf-binding-worker
+    env_file: .env
+    depends_on:
+      - web
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp:/tmp
+      - /pred_data/models:/pred_data/models:ro
+      - /pred_data/work:/pred_data/work:rw

--- a/pred/webserver/customresult.py
+++ b/pred/webserver/customresult.py
@@ -30,12 +30,13 @@ class CustomResultData(object):
         """
         cur = self.db.cursor()
         for line in self.bed_data.split("\n"):
-            parts = line.split("\t")
-            chrom = parts[0]
-            start = parts[1]
-            end = parts[2]
-            value = parts[3]
-            self.save_bed_row(cur, chrom, start, end, value)
+            parts = line.split()
+            if parts:
+                chrom = parts[0]
+                start = parts[1]
+                end = parts[2]
+                value = parts[3]
+                self.save_bed_row(cur, chrom, start, end, value)
         cur.close()
         self.db.commit()
 

--- a/webserver.py
+++ b/webserver.py
@@ -256,8 +256,9 @@ def post_custom_result():
     """
     required_prop_names = ["job_id", "bed_data", "model_name"]
     (job_id, bed_data, model_name) = get_required_json_props(request, required_prop_names)
+    decoded_bed_data = base64.b64decode(bed_data)
     result_uuid = CustomResultData.new_uuid()
-    result_data = CustomResultData(get_db(), result_uuid, job_id, model_name, bed_data)
+    result_data = CustomResultData(get_db(), result_uuid, job_id, model_name, decoded_bed_data)
     result_data.save()
     return make_json_response({'result': 'ok', 'id': result_uuid})
 


### PR DESCRIPTION
This branch is based on `predictions_tab` and not `master`.

docker-compose:
- Adds a section to docker-compose for starting a predictions_worker service:
- Uses dukegcb/predict-tf-binding-worker https://github.com/Duke-GCB/Predict-TF-Binding-Worker 
- Expects models and metadata to be available on host in `/pred_data/models`
- Adds `build: .` to the web service, allowing it to be rebuilt locally via `docker-compose build web`

webserver:
- Minor changes in webserver to handle the BED-formatted results (base64 decode and split on any whitespace)

Docker build:
- Reorders Dockerfile to prevent unnecessary cache misses
- Adds .dockerignore (symlink to .gitignore) to keep unnecessary or sensitive data out of docker image.
