### PR TITLE
promise polyfill for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "css-loader": "^0.23.1",
+    "es6-promise": "^3.2.1",
     "moment": "^2.14.1",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 var webpack = require('webpack');
 var path = require('path');
+require('es6-promise').polyfill();
 
 var BUILD_DIR = path.resolve(__dirname, 'src/build');
 var APP_DIR = path.resolve(__dirname, 'src/app');


### PR DESCRIPTION
Fixing webpack within Docker - added promise polyfill.
This was the error for every css loaded:

```
ERROR in ./~/css-loader!./src/app/<filename>.css
Module build failed: ReferenceError: Promise is not defined
```
