### PR TITLE
show empty rows for predictions where we didn't find anything

### DIFF
--- a/sql_templates/custom_job_tables.sql
+++ b/sql_templates/custom_job_tables.sql
@@ -34,17 +34,21 @@ create table job (
 
 -- Result of job requested by a user
 create table custom_result (
-  id uuid,
+  id uuid PRIMARY KEY,
   job_id uuid references job(id) NOT NULL,
-  model_name varchar NOT NULL,
+  model_name varchar NOT NULL
+);
+
+create index custom_result_search_idx on custom_result(model_name, job_id, id);
+
+create table custom_result_row (
+  result_id uuid references custom_result(id),
   name varchar NOT NULL,
   start integer NOT NULL,
   stop integer NOT NULL,
   value numeric NOT NULL
 );
 
-create index custom_result_name_idx on custom_result(id, name);
+create index custom_result_row_name_idx on custom_result_row(result_id, name);
+create index custom_result_row_value_idx on custom_result_row(result_id, abs(value) DESC);
 
-create index custom_result_value_idx on custom_result(id, abs(value) DESC);
-
-create index custom_result_search_idx on custom_result(model_name, job_id, id);


### PR DESCRIPTION
Broke custom_result into two tables to store empty results in a better manner.
custom_result is the parent that contains the result_id, job, and model name.
custom_result_row represents a single bed file record (result_id, start, stop, value).
Query does inner join on custom_result and outer join on custom_result_row so we will return a blank record when nothing matched.
