### PR TITLE
fix prediction details popup bed start

### DIFF
--- a/src/app/common/PredictionDetailTable.css
+++ b/src/app/common/PredictionDetailTable.css
@@ -1,0 +1,3 @@
+.PredictionDetailTable_table {
+    width: 300px;
+}

--- a/src/app/common/PredictionDetailTable.jsx
+++ b/src/app/common/PredictionDetailTable.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import ColorDNA from '../search/ColorDNA.jsx';
+require('./PredictionDetailTable.css');
+
+export default class PredictionDetailTable extends React.Component {
+    getHeader() {
+        return this.makeHeaderRow("Chromosome", "Start", "End", "Value", "Sequence");
+    }
+
+    makeHeaderRow(chrom, start, end, value, sequence) {
+        let {showChromosomeColumn} = this.props;
+        if (showChromosomeColumn) {
+            return <tr>
+                <th>{chrom}</th>
+                <th>{start}</th>
+                <th>{end}</th>
+                <th>{value}</th>
+                <th>{sequence}</th>
+            </tr>;
+        } else {
+            return <tr>
+                <th>{start}</th>
+                <th>{end}</th>
+                <th>{value}</th>
+                <th>{sequence}</th>
+            </tr>;
+        }
+    }
+
+    getDetails() {
+        let details = [];
+        let {detailList} = this.props;
+        for (let detail of detailList) {
+            let {rowClassName, chrom, start, end, value, seq} = detail;
+            details.push(this.makeRow(rowClassName, chrom, start, end, value, seq));
+        }
+        return details;
+    }
+
+    makeRow(rowClassName, chrom, start, end, value, sequence) {
+        let {showChromosomeColumn} = this.props;
+        if (showChromosomeColumn) {
+            return <tr className={rowClassName}>
+                <td>{chrom}</td>
+                <td>{start}</td>
+                <td>{end}</td>
+                <td>{value}</td>
+                <td><ColorDNA seq={sequence} /></td>
+            </tr>;
+        } else {
+            return <tr className={rowClassName}>
+                <td>{start}</td>
+                <td>{end}</td>
+                <td>{value}</td>
+                <td><ColorDNA seq={sequence} /></td>
+            </tr>;
+        }
+    }
+
+    render() {
+        let header = this.getHeader();
+        let details = this.getDetails();
+        return <table className="PredictionDetailTable_table table">
+            <thead>
+            {header}
+            </thead>
+            <tbody>
+            {details}
+            </tbody>
+        </table>
+    }
+
+}

--- a/src/app/search/PredictionDialog.jsx
+++ b/src/app/search/PredictionDialog.jsx
@@ -1,29 +1,10 @@
 import React from 'react';
-import Modal from 'react-modal';
+import Popup from '../common/Popup.jsx';
 import HeatMap from './HeatMap.jsx';
+import PredictionDetailTable from '../common/PredictionDetailTable.jsx';
 import GenomeBrowserURL from '../store/GenomeBrowserURL.js';
 import DnaSequences from '../store/DnaSequences.js';
-import ColorDNA from './ColorDNA.jsx';
-
-const customStyles = {
-    content : {
-
-    },
-    overlay : {
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        zIndex: 100,
-    }
-};
-
-function sortByStart(a, b) {
-  if (a.start < b.start) {
-    return -1;
-  }
-  if (a.start > b.start) {
-    return 1;
-  }
-  return 0;
-}
+import PredictionDetail from '../store/PredictionDetail.js';
 
 class PredictionDialog extends React.Component {
     constructor(props) {
@@ -33,105 +14,76 @@ class PredictionDialog extends React.Component {
         }
         this.onDnaRangesResponse = this.onDnaRangesResponse.bind(this);
         this.onDnaRangesError = this.onDnaRangesError.bind(this);
+        this.predictionDetail = new PredictionDetail();
     }
 
     componentDidUpdate() {
-        if (this.props.data) {
-            let dnaSequences = new DnaSequences(this.props.data.genome);
-            let values = this.props.data.values;
+        let {ranges} = this.state;
+        let {data} = this.props;
+        if (data) {
+            let dnaSequences = new DnaSequences(data.genome);
             let needsToUpdate = false;
-            if (values.length > 0) {
-                for (let i = 0; i < values.length; i++) {
-                    let prediction = values[i];
-                    let position = this.props.data.chrom + ":" + prediction.start + '-' + prediction.end;
-                    dnaSequences.addRangeRequest(position, this.props.data.chrom, prediction.start, prediction.end);
-                    if (position in this.state.ranges) {
-                        continue;
-                    }
-                    needsToUpdate = true;
+            for (let detailObj of this.predictionDetail.getDetails(data, data.chrom, undefined)) {
+                let {position, start, end} = detailObj;
+                // if we fetch one we must fetch all
+                dnaSequences.addRangeRequest(position, data.chrom, start, end);
+                if (position in ranges) {
+                    continue;
                 }
-                if (needsToUpdate) {
-                    dnaSequences.fetchRanges(this.onDnaRangesResponse, this.onDnaRangesError);
-                }
+                needsToUpdate = true;
+            }
+            if (needsToUpdate) {
+                dnaSequences.fetchRanges(this.onDnaRangesResponse, this.onDnaRangesError);
             }
         }
     }
 
-    onDnaRangesResponse(ranges) {
+    onDnaRangesResponse = (ranges) => {
         this.setState({
             'ranges': ranges
         })
     }
 
-    onDnaRangesError(error) {
+    onDnaRangesError = (error) => {
         alert(error);
     }
 
     render() {
-        if (!this.props.data) {
+        let {data, predictionColor} = this.props;
+        if (!data) {
             return <div></div>;
         }
-        let {predictionColor} = this.props;
-        let rowData = this.props.data;
-        let details = [];
-        let values = rowData.values.slice();
-        values.sort(sortByStart);
-        for (let i = 0; i < values.length; i++) {
-            let prediction = values[i];
-            let position = this.props.data.chrom + ":" + prediction.start  + '-' + prediction.end;
-            let seq = '';
-            if (position in this.state.ranges) {
-                seq = this.state.ranges[position];
-            }
-            details.push(<tr>
-                <td>{this.props.data.chrom}</td>
-                <td>{prediction.start}</td>
-                <td>{prediction.end}</td>
-                <td>{prediction.value}</td>
-                <td><ColorDNA seq={seq} /></td>
-            </tr>)
+        let detailList = [];
+        for (let detailObj of this.predictionDetail.getDetails(data, data.chrom, undefined)) {
+            let {chrom, start, end, value} = detailObj;
+            let seq = this.predictionDetail.getSeqFromRanges(detailObj, this.state.ranges);
+            detailObj.seq = seq;
+            detailList.push(detailObj);
         }
         let genomeBrowserURL = new GenomeBrowserURL('human', this.props.data.trackHubUrl);
         let allRangeGenomeBrowserURL = genomeBrowserURL.getPredictionURL(this.props.data.genome,
             this.props.data.chrom, this.props.data.start, this.props.data.end);
-        return <Modal className="Modal__Bootstrap modal-dialog modal-lg"
-                      isOpen={this.props.isOpen}
+        let title = "Predictions for " + data.title;
+        return <Popup isOpen={this.props.isOpen}
                       onRequestClose={this.props.onRequestClose}
-                      style={customStyles} >
-                    <div >
-                        <div className="modal-header">
-                          <button type="button" className="close" onClick={this.props.onRequestClose}>
-                            <span aria-hidden="true">&times;</span>
-                            <span className="sr-only">Close</span>
-                          </button>
-                          <h4 className="modal-title">Predictions for {rowData.title}</h4>
-                        </div>
-                        <div className="modal-body">
-                            <h5>Values (on {rowData.strand} strand)
-                                &nbsp;
-                                <a alt="View in Genome Browser" title="View in Genome Browser"
-                                   href={allRangeGenomeBrowserURL} target="_blank"
-                                   style={{float: 'right', paddingRight: '24px'}}
-                                >
-                                    View in Genome Browser (on + strand)
-                                </a>
-
-                            </h5>
-                            <HeatMap width="800" height="40"
-                                     data={rowData}
-                                     predictionColor={predictionColor} />
-                            <h5>Details</h5>
-                            <table className="table" style={{width: 300}}>
-                                <thead>
-                                    <tr><th>Chromosome</th><th>Start</th><th>End</th><th>Value</th><th>Sequence</th></tr>
-                                </thead>
-                                <tbody>
-                                    {details}
-                                </tbody>
-                            </table>
-                        </div>
-                  </div>
-                </Modal>
+                      title={title}>
+            <h5>Values (on {data.strand} strand)
+                &nbsp;
+                <a alt="View in Genome Browser" title="View in Genome Browser"
+                   href={allRangeGenomeBrowserURL} target="_blank"
+                   style={{float: 'right', paddingRight: '24px'}}>
+                    View in Genome Browser (on + strand)
+                </a>
+            </h5>
+            <HeatMap width="800" height="40"
+                     data={data}
+                     predictionColor={predictionColor}/>
+            <h5>Details</h5>
+            <PredictionDetailTable
+                showChromosomeColumn={true}
+                detailList={detailList}
+            />
+        </Popup>
     }
 }
 

--- a/src/app/store/PredictionDetail.js
+++ b/src/app/store/PredictionDetail.js
@@ -1,0 +1,66 @@
+// Allows user to create list of various properties based a list of bed file predictions.
+
+function sortByStart(a, b) {
+    if (a.start < b.start) {
+        return -1;
+    }
+    if (a.start > b.start) {
+        return 1;
+    }
+    return 0;
+}
+
+export default class PredictionDetail {
+    constructor() {
+
+    }
+
+    // return array of details for each value in rowData
+    getDetails(rowData, chrom, selectedIndex) {
+        let result = [];
+        let sortedValues = rowData.values.slice();
+        sortedValues.sort(sortByStart);
+        for (let i = 0; i < sortedValues.length; i++) {
+            let prediction = sortedValues[i];
+            result.push(this.makeDetail(prediction, chrom, i == selectedIndex));
+        }
+        return result;
+    }
+
+    makeDetail(prediction, chrom, isSelected) {
+            let start = parseInt(prediction.start) + 1;
+            let position = chrom + ":" + start + '-' + prediction.end;
+            let rowClassName = "";
+            if (isSelected) {
+                rowClassName = "active";
+            }
+            return {
+                rowClassName: rowClassName,
+                position: position,
+                chrom: chrom,
+                start: parseInt(prediction.start) + 1,
+                end: prediction.end,
+                value: prediction.value,
+            };
+    }
+
+    // given a detail object from getDetails lookup sequence from a dictionary of ranges with position keys
+    getSeqFromRanges(detailObject, ranges) {
+        let position = detailObject.position;
+        if (position in ranges) {
+            return ranges[position];
+        }
+        return '';
+    }
+
+    // given a detail object from getDetails lookup sequence from a parent sequence
+    getSeqFromParentSequence(detailObject, parentSequence) {
+        let start = detailObject.start;
+        let end = detailObject.end;
+        return parentSequence.substring(start, end);
+    }
+
+}
+
+
+

--- a/src/tests/testPredictionDetail.js
+++ b/src/tests/testPredictionDetail.js
@@ -1,0 +1,70 @@
+import PredictionDetail from './../app/store/PredictionDetail.js';
+var assert = require('chai').assert;
+
+describe('PredictionDetail', function () {
+    describe('getDetails()', function () {
+        it('should return sorted values with more properties', function () {
+            let rowData = {
+                values: [{
+                    start: 10,
+                    end: 20,
+                    value: 2.5
+                },{
+                    start: 1,
+                    end: 10,
+                    value: 12.5
+                }]
+            }
+            let predDetail = new PredictionDetail();
+            let detailAry = predDetail.getDetails(rowData, 'chr1', 0);
+            assert.equal(2, detailAry.length);
+
+            // FIRST ROW
+            // input start is bed value and display is +1
+            assert.equal(2, detailAry[0].start);
+            // end, value is same as input
+            assert.equal(10, detailAry[0].end);
+            assert.equal(12.5, detailAry[0].value);
+            //more properties
+            assert.equal('active', detailAry[0].rowClassName);
+            assert.equal('chr1:2-10', detailAry[0].position);
+            assert.equal('chr1', detailAry[0].chrom);
+
+            // SECOND ROW
+            // input start is bed value and display is +1
+            assert.equal(11, detailAry[1].start);
+            // end, value is same as input
+            assert.equal(20, detailAry[1].end);
+            assert.equal(2.5, detailAry[1].value);
+            //more properties
+            assert.equal('', detailAry[1].rowClassName);
+            assert.equal('chr1:11-20', detailAry[1].position);
+            assert.equal('chr1', detailAry[1].chrom);
+        });
+    });
+
+    describe('getSeqFromRanges()', function () {
+        it('should lookup value based on position', function () {
+            let ranges = {'chr1:1-10':'ACBGT'};
+            let detailObject = {
+                position: 'chr1:1-10',
+            }
+            let predDetail = new PredictionDetail();
+            let seq = predDetail.getSeqFromRanges(detailObject, ranges);
+            assert.equal('ACBGT', seq);
+        });
+    });
+
+    describe('getSeqFromParentSequence()', function () {
+        it('should substring based on start,end', function () {
+            let parentSequence = "ACGTACGTACGT"
+            let detailObject = {
+                start: 1,
+                end: 5
+            }
+            let predDetail = new PredictionDetail();
+            let seq = predDetail.getSeqFromParentSequence(detailObject, parentSequence);
+            assert.equal('CGTA', seq);
+        });
+    });
+});

--- a/webserver.py
+++ b/webserver.py
@@ -142,8 +142,8 @@ def get_sequences(genome):
     try:
         sequences = lookup_dna_sequence(g_config, genome, ranges)
         return make_json_response({'sequences': sequences})
-    except FileNotFoundError:
-        raise ValueError("Missing file for {}.".format(genome))
+    except IOError as err:
+        raise ValueError("Missing file for {}:{}.".format(genome, err))
 
 
 @app.route('/api/v1/sequences/<sequence_id>', methods=['GET'])


### PR DESCRIPTION
Fix displayed start values to be +1.
Start positions in bed file are 0 based but 1 based when displayed to users.
Moved this work into PredictionDetail.js
Simplified two prediction details screens
fix python2 issue in webserver

The FASTA tweak wasn't necessary as we were already using the biopython id property of the sequence instead of name(what we were using earlier).
