### PR TITLE
Adding minPreference and maxPreference to model setup.

### DIFF
--- a/src/app/common/ProgressTable.jsx
+++ b/src/app/common/ProgressTable.jsx
@@ -31,6 +31,9 @@ export default class ProgressTable extends React.Component {
         let started = moment(new Date(startedDate));
         let current = moment(new Date(currentDate));
         let elapsed = this.getEllapsed(started, current);
+        if (!startedDate) {
+            return <div></div>;
+        }
         return <table className="ProgressTable_table">
             <tbody>
             <tr className="ProgressTable_tr_even">

--- a/src/app/prediction/PredictionDetailsDialog.jsx
+++ b/src/app/prediction/PredictionDetailsDialog.jsx
@@ -8,26 +8,33 @@ export default class PredictionDetailsDialog extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            ranges: {},
-            selectedIndex: undefined,
-        }
+            selectedIndexList: []
+        };
         this.predictionDetail = new PredictionDetail();
     }
 
-    setSelectedIndex = (idx) => {
+    setSelectedIndex = (idxList) => {
         this.setState({
-            selectedIndex: idx
+            selectedIndexList: idxList
         });
+    };
+
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.data) {
+            this.setState({
+                selectedIndexList: []
+            });
+        }
     }
 
     render() {
-        let {selectedIndex} = this.state;
+        let {selectedIndexList} = this.state;
         let {data} = this.props;
         if (!data) {
             return <div></div>;
         }
         let detailList = [];
-        for (let detailObj of this.predictionDetail.getDetails(data, data.chrom, selectedIndex)) {
+        for (let detailObj of this.predictionDetail.getDetails(data, data.chrom, selectedIndexList)) {
             let {rowClassName, start, end, value} = detailObj;
             let seq = this.predictionDetail.getSeqFromParentSequence(detailObj, data.sequence);
             detailObj.seq = seq;
@@ -42,7 +49,8 @@ export default class PredictionDetailsDialog extends React.Component {
                      height="40"
                      data={data}
                      predictionColor={this.props.predictionColor}
-                     setSelectedIndex={this.setSelectedIndex} />
+                     setSelectedIndex={this.setSelectedIndex}
+                     />
             <h5>Details</h5>
             <PredictionDetailTable
                 showChromosomeColumn={false}

--- a/src/app/prediction/PredictionFilterPanel.jsx
+++ b/src/app/prediction/PredictionFilterPanel.jsx
@@ -121,7 +121,7 @@ class PredictionFilterPanel extends React.Component {
 
     render() {
         let {predictionColor, setPredictionColor, predictionSettings,
-            customSequenceList, preferenceMode} = this.props;
+            customSequenceList, showTwoColorPickers} = this.props;
         let modelOptions = this.makeModelOptions();
         let sequenceListOptions = this.makeSequenceListOptions();
         let uploadInstructions = <ArrowTooltip label={FIRST_TIME_INSTRUCTIONS}
@@ -150,7 +150,7 @@ class PredictionFilterPanel extends React.Component {
                           onChange={this.onChangeMaxPredictionSort}/>
             <BooleanInput checked={predictionSettings.all} label="All values (heatmap)"
                           onChange={this.onChangeAll}/>
-            <TFColorPickers showTwoPickers={preferenceMode}
+            <TFColorPickers showTwoPickers={showTwoColorPickers}
                             predictionColor={predictionColor}
                             setPredictionColor={setPredictionColor} />
             <UploadSequenceDialog isOpen={this.state.showCustomDialog}

--- a/src/app/prediction/PredictionPage.jsx
+++ b/src/app/prediction/PredictionPage.jsx
@@ -15,7 +15,7 @@ import CustomResultSearch from '../store/CustomResultSearch.js';
 import {CustomSequenceList} from '../store/CustomSequence.js';
 import {ITEMS_PER_PAGE, NUM_PAGE_BUTTONS} from '../store/AppSettings.js'
 import {SEQUENCE_NOT_FOUND} from '../store/Errors.js';
-import {isPreferenceModel, getFirstGenomeName} from '../store/GenomeData.js';
+import {getPreferenceSettings, getFirstGenomeName} from '../store/GenomeData.js';
 
 class PredictionPage extends React.Component {
     constructor(props) {
@@ -43,7 +43,6 @@ class PredictionPage extends React.Component {
             showGeneNamesWarnings: true,
             loadingStatusLabel: "",
             predictionColor: TFColorPickers.defaultColorObj(),
-            preferenceMode: false,
             customSequenceList: this.customSequenceList.get(),
             jobDates: {},
         };
@@ -181,12 +180,16 @@ class PredictionPage extends React.Component {
 
     downloadRawData = () => {
         return this.customResultSearch.getRawDownloadURL();
-    }
+    };
 
     render() {
-        let preferenceMode = isPreferenceModel(this.state.genomeData,
+        // Add preference min/max to color settings.
+        let preferenceSettings = getPreferenceSettings(this.state.genomeData,
             getFirstGenomeName(this.state.genomeData),
             this.state.predictionSettings.model);
+        let predictionColor = Object.assign({}, this.state.predictionColor);
+        Object.assign(predictionColor, preferenceSettings);
+
         let searchOperations = {
             search: this.search,
             changePage: this.changePage,
@@ -203,9 +206,9 @@ class PredictionPage extends React.Component {
                                                setPredictionSettings={this.setPredictionSettings}
                                                setErrorMessage={this.setErrorMessage}
                                                showCustomDialog={this.state.showCustomDialog}
-                                               predictionColor={this.state.predictionColor}
+                                               predictionColor={predictionColor}
                                                setPredictionColor={this.setPredictionColor}
-                                               preferenceMode={preferenceMode}
+                                               showTwoColorPickers={preferenceSettings.isPreference}
         />;
         let rightPanel = <PredictionResultsPanel genomeData={this.state.genomeData}
                                                  predictionSettings={this.state.predictionSettings}
@@ -219,9 +222,8 @@ class PredictionPage extends React.Component {
                                                  showCustomDialog={this.state.showCustomDialog}
                                                  predictionStore={this.predictionStore}
                                                  searchOperations={searchOperations}
-                                                 predictionColor={this.state.predictionColor}
+                                                 predictionColor={predictionColor}
                                                  showBlankWhenEmpty={noSequences}
-                                                 preferenceMode={preferenceMode}
                                                  jobDates={this.state.jobDates}
         />;
         return <div>

--- a/src/app/search/HeatMap.jsx
+++ b/src/app/search/HeatMap.jsx
@@ -68,7 +68,7 @@ class HeatMap extends React.Component {
         }
         return <g>
             {title}
-            <rect data-idx={idx} x={heatCell.x} y={0} width={heatCell.width} height={heatCell.height} style={{fill:heatCell.color}}
+            <rect data-idxlist={heatCell.idxList} x={heatCell.x} y={0} width={heatCell.width} height={heatCell.height} style={{fill:heatCell.color}}
                   onClick={this.drillDown} data-url={url}
             />
         </g>
@@ -81,8 +81,9 @@ class HeatMap extends React.Component {
             window.open(url);
         } else {
             if (setSelectedIndex) {
-                let idx = evt.target.getAttribute('data-idx');
-                setSelectedIndex(idx);
+                let indexListStr = evt.target.getAttribute('data-idxlist');
+                let indexes = indexListStr.split(",").map(function(x) { return parseInt(x);});
+                setSelectedIndex(indexes);
             }
         }
     }

--- a/src/app/search/SearchFilterPanel.jsx
+++ b/src/app/search/SearchFilterPanel.jsx
@@ -194,7 +194,7 @@ class SearchFilterPanel extends React.Component {
     }
 
     render() {
-        let {predictionColor, setPredictionColor, preferenceMode} = this.props;
+        let {predictionColor, setPredictionColor, preferenceSettings} = this.props;
         let secondGroupStyle = {marginLeft:'40px'};
         let streamInputStyle = {display: 'inline', width:'4em', marginRight: '10px'};
         let smallMargin = { margin: '10px' }
@@ -274,7 +274,7 @@ class SearchFilterPanel extends React.Component {
                                   geneListNames={geneListNames}
 
                 />
-                <TFColorPickers showTwoPickers={preferenceMode}
+                <TFColorPickers showTwoPickers={preferenceSettings.isPreference}
                                 predictionColor={predictionColor}
                                 setPredictionColor={setPredictionColor} />
         </div>

--- a/src/app/search/SearchPage.jsx
+++ b/src/app/search/SearchPage.jsx
@@ -11,7 +11,7 @@ import URLBuilder from '../store/URLBuilder.js'
 import PageBatch from '../store/PageBatch.js'
 import {fetchPredictionSettings} from '../store/PredictionSettings.js'
 import {ITEMS_PER_PAGE, NUM_PAGE_BUTTONS} from '../store/AppSettings.js'
-import {isPreferenceModel} from '../store/GenomeData.js';
+import {getPreferenceSettings} from '../store/GenomeData.js';
 
 
 class SearchPage extends React.Component {
@@ -32,7 +32,7 @@ class SearchPage extends React.Component {
              showCustomDialog: customListWithoutData,
              showGeneNamesWarnings: true,
              predictionColor: TFColorPickers.defaultColorObj(),
-             preferenceMode: false,
+             preferenceSettings: {},
          };
          this.search = this.search.bind(this);
          this.downloadAll = this.downloadAll.bind(this);
@@ -116,9 +116,11 @@ class SearchPage extends React.Component {
     };
 
     render () {
-        let preferenceMode = isPreferenceModel(this.state.genomeData,
+        let preferenceSettings = getPreferenceSettings(this.state.genomeData,
             this.state.searchSettings.genome,
             this.state.searchSettings.model);
+        let predictionColor = Object.assign({}, this.state.predictionColor);
+        Object.assign(predictionColor, preferenceSettings);
         let searchOperations = {
             search: this.search,
             changePage: this.changePage,
@@ -142,9 +144,9 @@ class SearchPage extends React.Component {
                                         maxBindingOffset={this.state.maxBindingOffset}
                                         setErrorMessage={this.setErrorMessage}
                                         showCustomDialog={this.state.showCustomDialog}
-                                        predictionColor={this.state.predictionColor}
+                                        predictionColor={predictionColor}
                                         setPredictionColor={this.setPredictionColor}
-                                        preferenceMode={preferenceMode}
+                                        preferenceSettings={preferenceSettings}
                                 />
                         </div>
                         <div className="col-md-10 col-sm-10 col-xs-10" >
@@ -162,8 +164,8 @@ class SearchPage extends React.Component {
 
                                 predictionStore={this.predictionStore}
                                 searchOperations={searchOperations}
-                                predictionColor={this.state.predictionColor}
-                                preferenceMode={preferenceMode}
+                                predictionColor={predictionColor}
+                                preferenceSettings={preferenceSettings}
                             />
                         </div>
 

--- a/src/app/store/ColorBlender.js
+++ b/src/app/store/ColorBlender.js
@@ -1,0 +1,103 @@
+// Creates CSS color string 'rgb(int, int, int)' given a prediction value and some settings.
+// This is done via: new ColorBlender(...).getColor()
+
+// colors allowed for predictionColor color1 and color2
+export const RED_COLOR_NAME = "red";
+export const GREEN_COLOR_NAME = "green";
+export const BLUE_COLOR_NAME = "blue";
+
+// alternate colors to use when we have both color1 and color 2
+export const YELLOW_COLOR_NAME = "yellow";
+export const CYAN_COLOR_NAME = "cyan";
+export const MAGENTA_COLOR_NAME = "magenta";
+
+const ALT_COLOR_LOOKUP = [
+    //color1         color2            alternate
+    [RED_COLOR_NAME, GREEN_COLOR_NAME, YELLOW_COLOR_NAME],
+    [RED_COLOR_NAME, BLUE_COLOR_NAME, MAGENTA_COLOR_NAME],
+    [GREEN_COLOR_NAME, BLUE_COLOR_NAME, CYAN_COLOR_NAME],
+];
+
+let COLOR_RGB = {};
+COLOR_RGB[RED_COLOR_NAME]       = [255,   0,   0];
+COLOR_RGB[GREEN_COLOR_NAME]     = [0,   128,   0];
+COLOR_RGB[BLUE_COLOR_NAME]      = [0,     0, 255];
+COLOR_RGB[YELLOW_COLOR_NAME]    = [255, 255,   0];
+COLOR_RGB[CYAN_COLOR_NAME]      = [0, 255,   255];
+COLOR_RGB[MAGENTA_COLOR_NAME]   = [255, 0,   255];
+
+export default class ColorBlender {
+    constructor(value, predictionColor, useAlternateColor) {
+        this.value = value;
+        this.predictionColor = predictionColor;
+        this.useAlternateColor = useAlternateColor;
+    }
+
+    isNegative() {
+        return this.value < 0;
+    }
+
+    determineColorName() {
+        if (this.useAlternateColor) {
+            return ColorBlender.lookupAlternateColorName(this.predictionColor.color1, this.predictionColor.color2);
+        } else {
+            if (this.isNegative()) {
+                return this.predictionColor.color2;
+            } else {
+                return this.predictionColor.color1;
+            }
+        }
+    }
+
+    getScaledValue() {
+        if (this.isNegative()) {
+            if (this.predictionColor.preferenceMin) {
+                return this.value / Math.abs(this.predictionColor.preferenceMin);
+            }
+        } else {
+            if (this.predictionColor.preferenceMax) {
+                return this.value / Math.abs(this.predictionColor.preferenceMax);
+            }
+        }
+        return this.value;
+    }
+
+    getColor() {
+        let colorName = this.determineColorName();
+        let colorRGB = COLOR_RGB[colorName];
+        let colorValues = ColorBlender.interpolateRGB(colorRGB[0], colorRGB[1], colorRGB[2], this.getScaledValue());
+        return this.getRGBString(colorValues);
+    }
+
+    getRGBString(rgbValues) {
+        let {r, g, b} = rgbValues;
+        return "rgb(" + r + "," + g + "," + b + ")";
+    }
+
+    static lookupAlternateColorName(color1Name, color2Name) {
+        for (let colAry of ALT_COLOR_LOOKUP) {
+            let c1 = colAry[0];
+            let c2 = colAry[1];
+            let alternate = colAry[2];
+            if ((c1 === color1Name && c2 == color2Name) || (c1 === color2Name && c2 == color1Name)) {
+                return alternate;
+            }
+        }
+        return color1Name;
+    }
+
+    // zeroColor it is always higher than oneColorInt
+    static interpolate(zeroColorInt, oneColorInt, value) {
+        let diff = zeroColorInt - oneColorInt;
+        return zeroColorInt - parseInt(Math.abs(value) * diff);
+    }
+
+    static interpolateRGB(r, g, b, value) {
+        let zeroColorInt = 255;
+        return {
+            r: ColorBlender.interpolate(zeroColorInt, r, value),
+            g: ColorBlender.interpolate(zeroColorInt, g, value),
+            b: ColorBlender.interpolate(zeroColorInt, b, value),
+        }
+    }
+}

--- a/src/app/store/ColorBlender.js
+++ b/src/app/store/ColorBlender.js
@@ -6,31 +6,15 @@ export const RED_COLOR_NAME = "red";
 export const GREEN_COLOR_NAME = "green";
 export const BLUE_COLOR_NAME = "blue";
 
-// alternate colors to use when we have both color1 and color 2
-export const YELLOW_COLOR_NAME = "yellow";
-export const CYAN_COLOR_NAME = "cyan";
-export const MAGENTA_COLOR_NAME = "magenta";
-
-const ALT_COLOR_LOOKUP = [
-    //color1         color2            alternate
-    [RED_COLOR_NAME, GREEN_COLOR_NAME, YELLOW_COLOR_NAME],
-    [RED_COLOR_NAME, BLUE_COLOR_NAME, MAGENTA_COLOR_NAME],
-    [GREEN_COLOR_NAME, BLUE_COLOR_NAME, CYAN_COLOR_NAME],
-];
-
 let COLOR_RGB = {};
 COLOR_RGB[RED_COLOR_NAME]       = [255,   0,   0];
 COLOR_RGB[GREEN_COLOR_NAME]     = [0,   128,   0];
 COLOR_RGB[BLUE_COLOR_NAME]      = [0,     0, 255];
-COLOR_RGB[YELLOW_COLOR_NAME]    = [255, 255,   0];
-COLOR_RGB[CYAN_COLOR_NAME]      = [0, 255,   255];
-COLOR_RGB[MAGENTA_COLOR_NAME]   = [255, 0,   255];
 
 export default class ColorBlender {
-    constructor(value, predictionColor, useAlternateColor) {
+    constructor(value, predictionColor) {
         this.value = value;
         this.predictionColor = predictionColor;
-        this.useAlternateColor = useAlternateColor;
     }
 
     isNegative() {
@@ -38,28 +22,26 @@ export default class ColorBlender {
     }
 
     determineColorName() {
-        if (this.useAlternateColor) {
-            return ColorBlender.lookupAlternateColorName(this.predictionColor.color1, this.predictionColor.color2);
+        if (this.isNegative()) {
+            return this.predictionColor.color2;
         } else {
-            if (this.isNegative()) {
-                return this.predictionColor.color2;
-            } else {
-                return this.predictionColor.color1;
-            }
+            return this.predictionColor.color1;
         }
     }
 
     getScaledValue() {
         if (this.isNegative()) {
-            if (this.predictionColor.preferenceMin) {
-                return this.value / Math.abs(this.predictionColor.preferenceMin);
-            }
+            return ColorBlender.scaleValue(this.value, this.predictionColor.preferenceMin);
         } else {
-            if (this.predictionColor.preferenceMax) {
-                return this.value / Math.abs(this.predictionColor.preferenceMax);
-            }
+            return ColorBlender.scaleValue(this.value, this.predictionColor.preferenceMax);
         }
-        return this.value;
+    }
+
+    static scaleValue(value, limitValue) {
+        if (limitValue) {
+            return value / Math.abs(limitValue);
+        }
+        return value;
     }
 
     getColor() {
@@ -72,18 +54,6 @@ export default class ColorBlender {
     getRGBString(rgbValues) {
         let {r, g, b} = rgbValues;
         return "rgb(" + r + "," + g + "," + b + ")";
-    }
-
-    static lookupAlternateColorName(color1Name, color2Name) {
-        for (let colAry of ALT_COLOR_LOOKUP) {
-            let c1 = colAry[0];
-            let c2 = colAry[1];
-            let alternate = colAry[2];
-            if ((c1 === color1Name && c2 == color2Name) || (c1 === color2Name && c2 == color1Name)) {
-                return alternate;
-            }
-        }
-        return color1Name;
     }
 
     // zeroColor it is always higher than oneColorInt

--- a/src/app/store/GenomeData.js
+++ b/src/app/store/GenomeData.js
@@ -1,3 +1,5 @@
+const PREFERENCE_TYPE = 'PREFERENCE';
+
 export function getTrackHubUrl(genomeData, genomeName) {
     return genomeData[genomeName].trackhubUrl;
 }
@@ -6,15 +8,25 @@ export function getFirstGenomeName(genomeData) {
     return Object.keys(genomeData)[0];
 }
 
-export function isPreferenceModel(genomeData, genomeName, modelName) {
+export function getPreferenceSettings(genomeData, genomeName, modelName) {
     let genomeObj = genomeData[genomeName];
     if (!genomeObj) {
-        return false;
+        return {
+            isPreference: false,
+        };
     }
     for (let modelObj of genomeObj.models) {
         if (modelObj.name == modelName) {
-            return modelObj.data_type == "PREFERENCE";
+            if (modelObj.data_type == PREFERENCE_TYPE) {
+                return {
+                    isPreference: true,
+                    preferenceMin: modelObj.preference_min,
+                    preferenceMax: modelObj.preference_max,
+                }
+            }
         }
     }
-    return false;
+    return {
+        isPreference: false,
+    }
 }

--- a/src/app/store/PredictionDetail.js
+++ b/src/app/store/PredictionDetail.js
@@ -16,13 +16,17 @@ export default class PredictionDetail {
     }
 
     // return array of details for each value in rowData
-    getDetails(rowData, chrom, selectedIndex) {
+    getDetails(rowData, chrom, selectedIndexList) {
         let result = [];
         let sortedValues = rowData.values.slice();
         sortedValues.sort(sortByStart);
         for (let i = 0; i < sortedValues.length; i++) {
             let prediction = sortedValues[i];
-            result.push(this.makeDetail(prediction, chrom, i == selectedIndex));
+            let isSelected = false;
+            if (selectedIndexList) {
+                isSelected = selectedIndexList.indexOf(i) != -1;
+            }
+            result.push(this.makeDetail(prediction, chrom, isSelected));
         }
         return result;
     }

--- a/src/tests/testColorBlender.js
+++ b/src/tests/testColorBlender.js
@@ -1,0 +1,125 @@
+import ColorBlender, {RED_COLOR_NAME, GREEN_COLOR_NAME, BLUE_COLOR_NAME,  YELLOW_COLOR_NAME,
+    CYAN_COLOR_NAME, MAGENTA_COLOR_NAME} from './../app/store/ColorBlender.js';
+var assert = require('chai').assert;
+
+describe('ColorBlender', function () {
+    describe('lookupAlternateColorName()', function () {
+        it('follow color wheel when given known items', function () {
+            assert.equal(YELLOW_COLOR_NAME, ColorBlender.lookupAlternateColorName(RED_COLOR_NAME, GREEN_COLOR_NAME));
+            assert.equal(YELLOW_COLOR_NAME, ColorBlender.lookupAlternateColorName(GREEN_COLOR_NAME, RED_COLOR_NAME));
+
+            assert.equal(MAGENTA_COLOR_NAME, ColorBlender.lookupAlternateColorName(RED_COLOR_NAME, BLUE_COLOR_NAME));
+            assert.equal(MAGENTA_COLOR_NAME, ColorBlender.lookupAlternateColorName(BLUE_COLOR_NAME, RED_COLOR_NAME));
+
+            assert.equal(CYAN_COLOR_NAME, ColorBlender.lookupAlternateColorName(BLUE_COLOR_NAME, GREEN_COLOR_NAME));
+            assert.equal(CYAN_COLOR_NAME, ColorBlender.lookupAlternateColorName(GREEN_COLOR_NAME, BLUE_COLOR_NAME));
+        });
+        it('return first color when given unknown groups', function () {
+            assert.equal(RED_COLOR_NAME, ColorBlender.lookupAlternateColorName(RED_COLOR_NAME, RED_COLOR_NAME));
+            assert.equal(RED_COLOR_NAME, ColorBlender.lookupAlternateColorName(RED_COLOR_NAME, 'anything'));
+        });
+    });
+
+    describe('isNegative()', function () {
+        it('true for values < 0', function () {
+            assert.equal(true, new ColorBlender(-1).isNegative());
+            assert.equal(true, new ColorBlender(-1.0).isNegative());
+        });
+        it('false for values >= 0', function () {
+            assert.equal(false, new ColorBlender(0).isNegative());
+            assert.equal(false, new ColorBlender(1).isNegative());
+            assert.equal(false, new ColorBlender(1.0).isNegative());
+        });
+    });
+
+    describe('determineColorName()', function () {
+        it('returns useAlternateColor ignoring value', function () {
+            let predictionColor = {
+                color1: RED_COLOR_NAME,
+                color2: BLUE_COLOR_NAME,
+            };
+            assert.equal(MAGENTA_COLOR_NAME, new ColorBlender(1, predictionColor, true).determineColorName());
+            assert.equal(MAGENTA_COLOR_NAME, new ColorBlender(-1, predictionColor, true).determineColorName());
+        });
+        it('returns color based on value when not useAlternateColor', function () {
+            let predictionColor = {
+                color1: RED_COLOR_NAME,
+                color2: BLUE_COLOR_NAME,
+            };
+            assert.equal(RED_COLOR_NAME, new ColorBlender(1, predictionColor, false).determineColorName());
+            assert.equal(BLUE_COLOR_NAME, new ColorBlender(-1, predictionColor, false).determineColorName());
+        });
+    });
+
+    describe('getScaledValue()', function () {
+        it('just returns value when no preferenceMin or preferenceMax', function () {
+            let predictionColor = {};
+            assert.equal(10, new ColorBlender(10, predictionColor).getScaledValue());
+            assert.equal(-10, new ColorBlender(-10, predictionColor).getScaledValue());
+        });
+        it('just scales value with abs preferenceMin/preferenceMax based on negative/positive values', function () {
+            let predictionColor = {
+                preferenceMax: 2,
+                preferenceMin: -5,
+            };
+            assert.equal(5, new ColorBlender(10, predictionColor).getScaledValue());
+            assert.equal(-2, new ColorBlender(-10, predictionColor).getScaledValue());
+        });
+    });
+
+    describe('getColor()', function () {
+        it('works for red and blue combination', function () {
+            let predictionColor = {
+                color1: RED_COLOR_NAME,
+                color2: BLUE_COLOR_NAME,
+            };
+            //test red values
+            assert.equal('rgb(255,0,0)', new ColorBlender(1.0, predictionColor, false).getColor());
+            assert.equal('rgb(255,128,128)', new ColorBlender(0.5, predictionColor, false).getColor());
+            assert.equal('rgb(255,255,255)', new ColorBlender(0.0, predictionColor, false).getColor());
+            //test blue values
+            assert.equal('rgb(0,0,255)', new ColorBlender(-1.0, predictionColor, false).getColor());
+            assert.equal('rgb(128,128,255)', new ColorBlender(-0.5, predictionColor, false).getColor());
+            //test magenta values
+            assert.equal('rgb(255,0,255)', new ColorBlender(1.0, predictionColor, true).getColor());
+            assert.equal('rgb(255,128,255)', new ColorBlender(0.5, predictionColor, true).getColor());
+
+        });
+    });
+
+    describe('interpolate()', function () {
+        it('work with 255 0 range', function () {
+            assert.equal(255, ColorBlender.interpolate(255, 0, 0.0));
+            assert.equal(128, ColorBlender.interpolate(255, 0, 0.5));
+            assert.equal(0, ColorBlender.interpolate(255, 0, 1.0));
+        });
+    });
+
+    describe('interpolateRGB()', function () {
+        it('red with 0 value is white', function () {
+            let white = { r: 255, g: 255, b: 255 };
+            assert.deepEqual(white, ColorBlender.interpolateRGB(255, 0, 0, 0.0));
+        });
+        it('red with 1 value is red', function () {
+            let red = { r: 255, g: 0, b: 0 };
+            assert.deepEqual(red, ColorBlender.interpolateRGB(255, 0, 0, 1.0));
+        });
+        it('red with 0.5 value is pink', function () {
+            let pink = { r: 255, g: 128, b: 128 };
+            assert.deepEqual(pink, ColorBlender.interpolateRGB(255, 0, 0, 0.5));
+        });
+
+        it('blue with 0 value is white', function () {
+            let white = { r: 255, g: 255, b: 255 };
+            assert.deepEqual(white, ColorBlender.interpolateRGB(0, 0, 255, 0.0));
+        });
+        it('blue with 1 value is blue', function () {
+            let blue = { r: 0, g: 0, b: 255 };
+            assert.deepEqual(blue, ColorBlender.interpolateRGB(0, 0, 255, 1.0));
+        });
+        it('blue with 0.5 value is light blue', function () {
+            let lightBlue = { r: 128, g: 128, b: 255 };
+            assert.deepEqual(lightBlue, ColorBlender.interpolateRGB(0, 0, 255, 0.5));
+        });
+    });
+});

--- a/src/tests/testColorBlender.js
+++ b/src/tests/testColorBlender.js
@@ -3,23 +3,6 @@ import ColorBlender, {RED_COLOR_NAME, GREEN_COLOR_NAME, BLUE_COLOR_NAME,  YELLOW
 var assert = require('chai').assert;
 
 describe('ColorBlender', function () {
-    describe('lookupAlternateColorName()', function () {
-        it('follow color wheel when given known items', function () {
-            assert.equal(YELLOW_COLOR_NAME, ColorBlender.lookupAlternateColorName(RED_COLOR_NAME, GREEN_COLOR_NAME));
-            assert.equal(YELLOW_COLOR_NAME, ColorBlender.lookupAlternateColorName(GREEN_COLOR_NAME, RED_COLOR_NAME));
-
-            assert.equal(MAGENTA_COLOR_NAME, ColorBlender.lookupAlternateColorName(RED_COLOR_NAME, BLUE_COLOR_NAME));
-            assert.equal(MAGENTA_COLOR_NAME, ColorBlender.lookupAlternateColorName(BLUE_COLOR_NAME, RED_COLOR_NAME));
-
-            assert.equal(CYAN_COLOR_NAME, ColorBlender.lookupAlternateColorName(BLUE_COLOR_NAME, GREEN_COLOR_NAME));
-            assert.equal(CYAN_COLOR_NAME, ColorBlender.lookupAlternateColorName(GREEN_COLOR_NAME, BLUE_COLOR_NAME));
-        });
-        it('return first color when given unknown groups', function () {
-            assert.equal(RED_COLOR_NAME, ColorBlender.lookupAlternateColorName(RED_COLOR_NAME, RED_COLOR_NAME));
-            assert.equal(RED_COLOR_NAME, ColorBlender.lookupAlternateColorName(RED_COLOR_NAME, 'anything'));
-        });
-    });
-
     describe('isNegative()', function () {
         it('true for values < 0', function () {
             assert.equal(true, new ColorBlender(-1).isNegative());
@@ -33,21 +16,13 @@ describe('ColorBlender', function () {
     });
 
     describe('determineColorName()', function () {
-        it('returns useAlternateColor ignoring value', function () {
+        it('returns color based on value', function () {
             let predictionColor = {
                 color1: RED_COLOR_NAME,
                 color2: BLUE_COLOR_NAME,
             };
-            assert.equal(MAGENTA_COLOR_NAME, new ColorBlender(1, predictionColor, true).determineColorName());
-            assert.equal(MAGENTA_COLOR_NAME, new ColorBlender(-1, predictionColor, true).determineColorName());
-        });
-        it('returns color based on value when not useAlternateColor', function () {
-            let predictionColor = {
-                color1: RED_COLOR_NAME,
-                color2: BLUE_COLOR_NAME,
-            };
-            assert.equal(RED_COLOR_NAME, new ColorBlender(1, predictionColor, false).determineColorName());
-            assert.equal(BLUE_COLOR_NAME, new ColorBlender(-1, predictionColor, false).determineColorName());
+            assert.equal(RED_COLOR_NAME, new ColorBlender(1, predictionColor).determineColorName());
+            assert.equal(BLUE_COLOR_NAME, new ColorBlender(-1, predictionColor).determineColorName());
         });
     });
 
@@ -74,15 +49,12 @@ describe('ColorBlender', function () {
                 color2: BLUE_COLOR_NAME,
             };
             //test red values
-            assert.equal('rgb(255,0,0)', new ColorBlender(1.0, predictionColor, false).getColor());
-            assert.equal('rgb(255,128,128)', new ColorBlender(0.5, predictionColor, false).getColor());
-            assert.equal('rgb(255,255,255)', new ColorBlender(0.0, predictionColor, false).getColor());
+            assert.equal('rgb(255,0,0)', new ColorBlender(1.0, predictionColor).getColor());
+            assert.equal('rgb(255,128,128)', new ColorBlender(0.5, predictionColor).getColor());
+            assert.equal('rgb(255,255,255)', new ColorBlender(0.0, predictionColor).getColor());
             //test blue values
-            assert.equal('rgb(0,0,255)', new ColorBlender(-1.0, predictionColor, false).getColor());
-            assert.equal('rgb(128,128,255)', new ColorBlender(-0.5, predictionColor, false).getColor());
-            //test magenta values
-            assert.equal('rgb(255,0,255)', new ColorBlender(1.0, predictionColor, true).getColor());
-            assert.equal('rgb(255,128,255)', new ColorBlender(0.5, predictionColor, true).getColor());
+            assert.equal('rgb(0,0,255)', new ColorBlender(-1.0, predictionColor).getColor());
+            assert.equal('rgb(128,128,255)', new ColorBlender(-0.5, predictionColor).getColor());
 
         });
     });

--- a/src/tests/testHeatMapData.js
+++ b/src/tests/testHeatMapData.js
@@ -1,176 +1,167 @@
-import HeatMapData from './../app/store/HeatMapData.js';
+import HeatMapData, {OverlappingList} from './../app/store/HeatMapData.js';
 var assert = require('chai').assert;
-/*
-describe('HeatMapData', function () {
 
-    describe('getColor()', function () {
-        it('should return white for 0.0 value', function () {
-            var hmd = new HeatMapData('chr1', {value: 0.0});
-            var result = hmd.getColor();
-            assert.equal(result, 'rgb(255,255,255)');
+describe('OverlappingList', function () {
+    describe('itemsOverlap()', function () {
+        it('return false for non-overlapping items', function () {
+            var item1 = {start:1,end:5};
+            var item2 = {start:6,end:10};
+            assert.equal(false, OverlappingList.itemsOverlap(item1, item2));
+            assert.equal(false, OverlappingList.itemsOverlap(item2, item1));
         });
-        it('should return red for 1.0 value', function () {
-            var hmd = new HeatMapData('chr1', {value: 1.0});
-            var result = hmd.getColor();
-            assert.equal(result, 'rgb(255,0,0)');
+       it('return false for almost-overlapping items', function () {
+            var item1 = {start:1,end:5};
+            var item2 = {start:5,end:10};
+            assert.equal(false, OverlappingList.itemsOverlap(item1, item2));
+            assert.equal(false, OverlappingList.itemsOverlap(item2, item1));
         });
-        it('should return pink for 0.5 value', function () {
-            var hmd = new HeatMapData('chr1', {value: 0.5});
-            var result = hmd.getColor();
-            assert.equal(result, 'rgb(255,127,127)');
+       it('return true for overlapping items', function () {
+            var item1 = {start:1,end:5};
+            var item2 = {start:4,end:10};
+            assert.equal(true, OverlappingList.itemsOverlap(item1, item2));
+            assert.equal(true, OverlappingList.itemsOverlap(item2, item1));
         });
     });
 
-    describe('getX()', function () {
-        it('should return 0 when offset is 10 and x start is 10', function () {
-            var hmd = new HeatMapData('chr1', {start: 10}, 10);
-            var result = hmd.getX(1);
-            assert.equal(result, 0);
+    describe('getUniqueIndexes()', function () {
+        it('works for two non-overlapping children', function () {
+            let indexes = OverlappingList.getUniqueIndexes([
+                {start:1,end:5},
+                {start:6,end:10}
+            ]);
+            assert.deepEqual(indexes, [1,5,6,10]);
         });
-        it('should return 10 when offset is 0 and x start is 10', function () {
-            var hmd = new HeatMapData('chr1', {start: 10});
-            var result = hmd.getX(1);
-            assert.equal(result, 10);
+        it('works for two overlapping children', function () {
+            let indexes = OverlappingList.getUniqueIndexes([
+                {start:1,end:5},
+                {start:3,end:10}
+            ]);
+            assert.deepEqual(indexes, [1,3,5,10]);
         });
-        it('should be 20 when start is 10 and scale is 2', function () {
-            var hmd = new HeatMapData('chr1', {start: 10});
-            var result = hmd.getX(2);
-            assert.equal(result, 20);
+
+        it('works for three overlapping children', function () {
+            let indexes = OverlappingList.getUniqueIndexes([
+                {start:1,end:20},
+                {start:3,end:6},
+                {start:7,end:10}
+            ]);
+            assert.deepEqual(indexes, [1,3,6,7,10,20]);
         });
-        it('should be 5 when start is 10 and scale is 0.5', function () {
-            var hmd = new HeatMapData('chr1', {start: 10});
-            var result = hmd.getX(0.5);
-            assert.equal(result, 5);
+        it('real world example', function () {
+            let indexes = OverlappingList.getUniqueIndexes([
+                {start:40,end:66, value:1},
+                {start:67,end:93, value:2},
+                {start:28,end:54, value:-3},
+                {start:36,end:62, value:-4}]);
+            assert.deepEqual(indexes, [28,36,40,54,62,66,67,93]);
         });
     });
-
-    describe('getWidth()', function () {
-        it('for scale 1 width should be PREDICTION_WIDTH', function () {
-            var hmd = new HeatMapData('chr1', {});
-            var result = hmd.getWidth(1);
-            assert.equal(result, 20);
-        });
-        it('for scale 0.1 width should be PREDICTION_WIDTH/10', function () {
-            var hmd = new HeatMapData('chr1', {});
-            var result = hmd.getWidth(0.1);
-            assert.equal(result, 2);
-        });
-        it('width should always be >= 1', function () {
-            var hmd = new HeatMapData('chr1', {});
-            var result = hmd.getWidth(0.001);
-            assert.equal(result, 1);
-        });
-    });
-
-    describe('getTitle()', function () {
-        it('Default title should be empty', function () {
-            var hmd = new HeatMapData('chr1', {start:1,end:2, value:3});
-            var hmdX = hmd.getTitle();
-            assert.equal(hmdX, '');
-        });
-        it('Default title should be a string when includeTitle is true', function () {
-            var hmd = new HeatMapData('chr1', {start:1,end:2, value:3}, 0, true);
-            var result = hmd.getTitle();
-            assert.equal(result, 'chr1:1-2 -> 3');
-        });
-    });
-
-    describe('buildCellArray()', function () {
-        it('should should be sorted by value low to high', function () {
-            var inputArray = [{start:1,end:2, value:1}, {start:4,end:5, value:0}];
-            var inputArray = [{start:1,end:2, value:1}, {start:4,end:5, value:0}];
-            var result = HeatMapData.buildCellArray('chr1', inputArray, {
-                xOffset: 0,
-                includeTitle: true,
-                scale: 1,
-                height: 10,
-            });
-            assert.equal(result.length, 2);
-            assert.equal(result[0].color, 'rgb(255,255,255)');
-            assert.equal(result[1].color, 'rgb(255,0,0)');
-        });
-        it('should fill in color, x, width, height and title', function () {
-            var inputArray = [{start:1,end:2, value:1}, {start:4,end:5, value:0}];
-            var result = HeatMapData.buildCellArray('chr1', inputArray, {
-                xOffset: 0,
-                includeTitle: true,
-                scale: 1,
-                height: 10,
-            });
-            assert.equal(result.length, 2);
-            var item = result[0];
-            assert.equal(item.color, 'rgb(255,255,255)');
-            assert.equal(item.x, 4);
-            assert.equal(item.width, 20);
-            assert.equal(item.height, 10);
-            assert.equal(item.title, 'chr1:1-2 -> 1\nchr1:4-5 -> 0');
-
-            item = result[1];
-            assert.equal(item.color, 'rgb(255,0,0)');
-            assert.equal(item.x, 1);
-            assert.equal(item.width, 20);
-            assert.equal(item.height, 10);
-            assert.equal(item.title, 'chr1:1-2 -> 1\nchr1:4-5 -> 0');
-        });
-
-        it('overlapping items should not titles if includeTitle is disabled', function () {
-            var inputArray = [
-                {start:1,end:5, value:1},
-                {start:4,end:1, value:0},
+    describe('makeUniqueGroupsForChildren()', function () {
+        it('works for one child', function () {
+            let children = [
+                {start:1,end:5},
             ];
-            var result = HeatMapData.buildCellArray('chr1', inputArray, {
-                xOffset: 0,
-                includeTitle: false,
-                scale: 1,
-                height: 10,
-            });
-            assert.equal(result.length, 2);
-            assert.equal(result[0].title, '');
-            assert.equal(result[1].title, '');
+            let itemAry = OverlappingList.makeUniqueGroupsForChildren(children);
+            let groupStr = OverlappingList.itemAryToString(itemAry);
+            assert.include(groupStr, '[1,5 children_len:1]');
+        });
+        it('works for two children', function () {
+            let children = [
+                {start:1,end:5},
+                {start:4,end:6},
+            ];
+            let itemAry = OverlappingList.makeUniqueGroupsForChildren(children);
+            let groupStr = OverlappingList.itemAryToString(itemAry);
+            assert.include(groupStr, '[1,4 children_len:1]');
+            assert.include(groupStr, '[4,5 children_len:2]');
+            assert.include(groupStr, '[5,6 children_len:1]');
         });
 
-
-        it('overlapping items should share titles seperated by newline', function () {
-            var inputArray = [
-                {start:1,end:5, value:1},
-                {start:4,end:7, value:0},
+        it('works for three children', function () {
+            let children = [
+                {start:1,end:10},
+                {start:3,end:4},
+                {start:5,end:6},
             ];
-            var result = HeatMapData.buildCellArray('chr1', inputArray, {
-                xOffset: 0,
-                includeTitle: true,
-                scale: 1,
-                height: 10,
-            });
-            assert.equal(result.length, 2);
-            assert.equal(result[0].title, 'chr1:1-5 -> 1\nchr1:4-7 -> 0');
-            assert.equal(result[1].title, 'chr1:1-5 -> 1\nchr1:4-7 -> 0');
+            let itemAry = OverlappingList.makeUniqueGroupsForChildren(children);
+            let groupStr = OverlappingList.itemAryToString(itemAry);
+            assert.include(groupStr, '[1,3 children_len:1]');
+            assert.include(groupStr, '[3,4 children_len:2]');
+            assert.include(groupStr, '[5,6 children_len:2]');
+            assert.include(groupStr, '[6,10 children_len:1]');
         });
+        it('real world example', function () {
+            let children = [
+                {start:40,end:66, value:1},
+                {start:67,end:93, value:2},
+                {start:28,end:54, value:-3},
+                {start:36,end:62, value:-4}];
+            let itemAry = OverlappingList.makeUniqueGroupsForChildren(children);
 
-        it('overlapping items should not combine everything', function () {
-            var inputArray = [
-                {end: 714177, start: 714157, value: 0.2967},
-                {end: 713995, start: 713975, value: 0.3168},
-                {end: 714022, start: 714002, value: 0.3133},
-                {end: 713931, start: 713911, value: 0.215},
-                {end: 714070, start: 714050, value: 0.3345},
-                {end: 714020, start: 714000, value: 0.2865},
-            ];
-            var result = HeatMapData.buildCellArray('chr1', inputArray, {
-                xOffset: 713931,
-                includeTitle: true,
-                scale: 1,
-                height: 10,
-            });
-            // ordered by prediction low to high
-            // items that overlap in the x direction share titles: so 714000 and n714002 share title.
-            assert.equal(result.length, 6);
-            assert.equal(result[0].title, 'chr1:713911-713931 -> 0.215');
-            assert.equal(result[1].title, 'chr1:714000-714020 -> 0.2865\nchr1:714002-714022 -> 0.3133');
-            assert.equal(result[2].title, 'chr1:714157-714177 -> 0.2967');
-            assert.equal(result[3].title, 'chr1:714000-714020 -> 0.2865\nchr1:714002-714022 -> 0.3133');
-            assert.equal(result[4].title, 'chr1:713975-713995 -> 0.3168');
-            assert.equal(result[5].title, 'chr1:714050-714070 -> 0.3345');
+            assert.equal(6, itemAry.length);
+            let groupStr = OverlappingList.itemAryToString(itemAry);
+            assert.include(groupStr, '[28,36 children_len:1]');
+            assert.include(groupStr, '[36,40 children_len:2]');
+            assert.include(groupStr, '[40,54 children_len:3]');
+            assert.include(groupStr, '[54,62 children_len:2]');
+            assert.include(groupStr, '[62,66 children_len:1]');
+            assert.include(groupStr, '[67,93 children_len:1]');
         });
 
     });
-});*/
+
+    describe('flatten()', function () {
+        it('add two separate', function () {
+            let overlappingList = new OverlappingList();
+            overlappingList.add({start:1,end:5});
+            overlappingList.add({start:6,end:10});
+            let flattened = overlappingList.flatten();
+            assert.equal(flattened.length, 2);
+            let flattenedStr = OverlappingList.itemAryToString(flattened);
+            assert.include(flattenedStr, '[1,5 children_len:1]');
+            assert.include(flattenedStr, '[6,10 children_len:1]');
+        });
+        it('add two separate then combine both for a third that overlaps', function () {
+            let overlappingList = new OverlappingList();
+            overlappingList.add({start:1,end:5});
+            overlappingList.add({start:6,end:10});
+            overlappingList.add({start:4,end:7});
+            let flattened = overlappingList.flatten();
+            assert.equal(flattened.length, 5);
+            let flattenedStr = OverlappingList.itemAryToString(flattened);
+            assert.include(flattenedStr, '[1,4 children_len:1]');
+            assert.include(flattenedStr, '[4,5 children_len:2]');
+            assert.include(flattenedStr, '[5,6 children_len:1]');
+            assert.include(flattenedStr, '[6,7 children_len:2]');
+            assert.include(flattenedStr, '[7,10 children_len:1]');
+        });
+        it('add two separate then combine both for a third that overlaps first', function () {
+            let overlappingList = new OverlappingList();
+            overlappingList.add({start:1,end:5});
+            overlappingList.add({start:7,end:10});
+            overlappingList.add({start:4,end:7});
+            let flattened = overlappingList.flatten();
+            assert.equal(flattened.length, 4);
+            let flattenedStr = OverlappingList.itemAryToString(flattened);
+            assert.include(flattenedStr, '[1,4 children_len:1]');
+            assert.include(flattenedStr, '[4,5 children_len:2]');
+            assert.include(flattenedStr, '[5,7 children_len:1]');
+            assert.include(flattenedStr, '[7,10 children_len:1]');
+        });
+        it('real world example', function () {
+            let overlappingList = new OverlappingList();
+            overlappingList.add({start:40,end:66, value:1});
+            overlappingList.add({start:67,end:93, value:2});
+            overlappingList.add({start:28,end:54, value:-3});
+            overlappingList.add({start:36,end:62, value:-4});
+            let flattened = overlappingList.flatten();
+            assert.equal(flattened.length, 6);
+            let flattenedStr = OverlappingList.itemAryToString(flattened);
+            assert.include(flattenedStr, '[28,36 children_len:1]');
+            assert.include(flattenedStr, '[36,40 children_len:2]');
+            assert.include(flattenedStr, '[40,54 children_len:3]');
+            assert.include(flattenedStr, '[54,62 children_len:2]');
+            assert.include(flattenedStr, '[62,66 children_len:1]');
+        });
+    });
+});

--- a/src/tests/testHeatMapData.js
+++ b/src/tests/testHeatMapData.js
@@ -23,93 +23,6 @@ describe('OverlappingList', function () {
         });
     });
 
-    describe('getUniqueIndexes()', function () {
-        it('works for two non-overlapping children', function () {
-            let indexes = OverlappingList.getUniqueIndexes([
-                {start:1,end:5},
-                {start:6,end:10}
-            ]);
-            assert.deepEqual(indexes, [1,5,6,10]);
-        });
-        it('works for two overlapping children', function () {
-            let indexes = OverlappingList.getUniqueIndexes([
-                {start:1,end:5},
-                {start:3,end:10}
-            ]);
-            assert.deepEqual(indexes, [1,3,5,10]);
-        });
-
-        it('works for three overlapping children', function () {
-            let indexes = OverlappingList.getUniqueIndexes([
-                {start:1,end:20},
-                {start:3,end:6},
-                {start:7,end:10}
-            ]);
-            assert.deepEqual(indexes, [1,3,6,7,10,20]);
-        });
-        it('real world example', function () {
-            let indexes = OverlappingList.getUniqueIndexes([
-                {start:40,end:66, value:1},
-                {start:67,end:93, value:2},
-                {start:28,end:54, value:-3},
-                {start:36,end:62, value:-4}]);
-            assert.deepEqual(indexes, [28,36,40,54,62,66,67,93]);
-        });
-    });
-    describe('makeUniqueGroupsForChildren()', function () {
-        it('works for one child', function () {
-            let children = [
-                {start:1,end:5},
-            ];
-            let itemAry = OverlappingList.makeUniqueGroupsForChildren(children);
-            let groupStr = OverlappingList.itemAryToString(itemAry);
-            assert.include(groupStr, '[1,5 children_len:1]');
-        });
-        it('works for two children', function () {
-            let children = [
-                {start:1,end:5},
-                {start:4,end:6},
-            ];
-            let itemAry = OverlappingList.makeUniqueGroupsForChildren(children);
-            let groupStr = OverlappingList.itemAryToString(itemAry);
-            assert.include(groupStr, '[1,4 children_len:1]');
-            assert.include(groupStr, '[4,5 children_len:2]');
-            assert.include(groupStr, '[5,6 children_len:1]');
-        });
-
-        it('works for three children', function () {
-            let children = [
-                {start:1,end:10},
-                {start:3,end:4},
-                {start:5,end:6},
-            ];
-            let itemAry = OverlappingList.makeUniqueGroupsForChildren(children);
-            let groupStr = OverlappingList.itemAryToString(itemAry);
-            assert.include(groupStr, '[1,3 children_len:1]');
-            assert.include(groupStr, '[3,4 children_len:2]');
-            assert.include(groupStr, '[5,6 children_len:2]');
-            assert.include(groupStr, '[6,10 children_len:1]');
-        });
-        it('real world example', function () {
-            let children = [
-                {start:40,end:66, value:1},
-                {start:67,end:93, value:2},
-                {start:28,end:54, value:-3},
-                {start:36,end:62, value:-4}];
-            let itemAry = OverlappingList.makeUniqueGroupsForChildren(children);
-
-            assert.equal(6, itemAry.length);
-            let groupStr = OverlappingList.itemAryToString(itemAry);
-            assert.include(groupStr, '[28,36 children_len:1]');
-            assert.include(groupStr, '[36,40 children_len:2]');
-            assert.include(groupStr, '[40,54 children_len:3]');
-            assert.include(groupStr, '[54,62 children_len:2]');
-            assert.include(groupStr, '[62,66 children_len:1]');
-            assert.include(groupStr, '[67,93 children_len:1]');
-        });
-
-    });
-
     describe('flatten()', function () {
         it('add two separate', function () {
             let overlappingList = new OverlappingList();
@@ -127,13 +40,11 @@ describe('OverlappingList', function () {
             overlappingList.add({start:6,end:10});
             overlappingList.add({start:4,end:7});
             let flattened = overlappingList.flatten();
-            assert.equal(flattened.length, 5);
+            assert.equal(flattened.length, 3);
             let flattenedStr = OverlappingList.itemAryToString(flattened);
-            assert.include(flattenedStr, '[1,4 children_len:1]');
-            assert.include(flattenedStr, '[4,5 children_len:2]');
-            assert.include(flattenedStr, '[5,6 children_len:1]');
-            assert.include(flattenedStr, '[6,7 children_len:2]');
-            assert.include(flattenedStr, '[7,10 children_len:1]');
+            assert.include(flattenedStr, '[1,5 children_len:2]');
+            assert.include(flattenedStr, '[6,10 children_len:2]');
+            assert.include(flattenedStr, '[4,7 children_len:3]');
         });
         it('add two separate then combine both for a third that overlaps first', function () {
             let overlappingList = new OverlappingList();
@@ -141,11 +52,10 @@ describe('OverlappingList', function () {
             overlappingList.add({start:7,end:10});
             overlappingList.add({start:4,end:7});
             let flattened = overlappingList.flatten();
-            assert.equal(flattened.length, 4);
+            assert.equal(flattened.length, 3);
             let flattenedStr = OverlappingList.itemAryToString(flattened);
-            assert.include(flattenedStr, '[1,4 children_len:1]');
-            assert.include(flattenedStr, '[4,5 children_len:2]');
-            assert.include(flattenedStr, '[5,7 children_len:1]');
+            assert.include(flattenedStr, '[1,5 children_len:2]');
+            assert.include(flattenedStr, '[4,7 children_len:2]');
             assert.include(flattenedStr, '[7,10 children_len:1]');
         });
         it('real world example', function () {
@@ -155,13 +65,12 @@ describe('OverlappingList', function () {
             overlappingList.add({start:28,end:54, value:-3});
             overlappingList.add({start:36,end:62, value:-4});
             let flattened = overlappingList.flatten();
-            assert.equal(flattened.length, 6);
+            assert.equal(flattened.length, 4);
             let flattenedStr = OverlappingList.itemAryToString(flattened);
-            assert.include(flattenedStr, '[28,36 children_len:1]');
-            assert.include(flattenedStr, '[36,40 children_len:2]');
-            assert.include(flattenedStr, '[40,54 children_len:3]');
-            assert.include(flattenedStr, '[54,62 children_len:2]');
-            assert.include(flattenedStr, '[62,66 children_len:1]');
+            assert.include(flattenedStr, '[40,66 children_len:3]');
+            assert.include(flattenedStr, '[67,93 children_len:1]');
+            assert.include(flattenedStr, '[28,54 children_len:3]');
+            assert.include(flattenedStr, '[36,62 children_len:3]');
         });
     });
 });

--- a/src/tests/testPredictionDetail.js
+++ b/src/tests/testPredictionDetail.js
@@ -16,7 +16,7 @@ describe('PredictionDetail', function () {
                 }]
             }
             let predDetail = new PredictionDetail();
-            let detailAry = predDetail.getDetails(rowData, 'chr1', 0);
+            let detailAry = predDetail.getDetails(rowData, 'chr1', [0]);
             assert.equal(2, detailAry.length);
 
             // FIRST ROW


### PR DESCRIPTION
Adding minPreference and maxPreference to handle scaling of negative and positive preference range data. These values will be calculated per preference data setup. They represent the range of negative and postitive preference data. When rendering the heatmaps we will divide the negative values by abs(minPreference) and positive by maxPreference.This should give is a number between 0 and 1 that we can use to determine the intensity of the rect in the heatmap.

Also added type to the model setup(set to 'PREFERENCE' to enable preference mode). The default mode is 'PREDICTION'.
Preference mode shows two color pickers and will scale color values in the heatmap.

Example predictionsconf.yaml for a preference model with -11 to 20 range of prediction data:

```
...
    prediction_lists:
      -
        name: "ELT1_vs_ETS1"
        url: "http://track..."
        fix_script: "bigBedToBed"
        type: "PREFERENCE"
        preference_max: 20
        preference_min: -11
...
```
