### PR TITLE
underline core in prediction details

### DIFF
--- a/pred/config.py
+++ b/pred/config.py
@@ -122,8 +122,10 @@ class GenomeData(object):
             type = prediction_data.get('type', 'PREDICTION')
             preference_min = prediction_data.get('preference_min', None)
             preference_max = prediction_data.get('preference_max', None)
+            core_offset = prediction_data.get('core_offset', None)
+            core_length = prediction_data.get('core_length', None)
             prediction = PredictionSettings(name, url, self.genomename, fix_script, sort_max_guess, type,
-                                            preference_min, preference_max)
+                                            preference_min, preference_max, core_offset, core_length)
             self.prediction_lists.append(prediction)
 
     def get_model_types_str(self):
@@ -142,7 +144,8 @@ class GeneInfoSettings(object):
 
 
 class PredictionSettings(object):
-    def __init__(self, name, url, genome, fix_script, sort_max_guess, data_type, preference_min, preference_max):
+    def __init__(self, name, url, genome, fix_script, sort_max_guess, data_type, preference_min, preference_max,
+                 core_offset, core_length):
         self.name = name
         self.url = url
         self.genome = genome
@@ -151,6 +154,8 @@ class PredictionSettings(object):
         self.data_type = data_type
         self.preference_min = preference_min
         self.preference_max = preference_max
+        self.core_offset = core_offset
+        self.core_length = core_length
 
     def get_data(self):
         """
@@ -161,6 +166,8 @@ class PredictionSettings(object):
             'name': self.name,
             'data_type': self.data_type,
             'preference_min': self.preference_min,
-            'preference_max': self.preference_max
+            'preference_max': self.preference_max,
+            'core_offset': self.core_offset,
+            'core_length': self.core_length,
         }
 

--- a/src/app/common/PredictionDetailTable.jsx
+++ b/src/app/common/PredictionDetailTable.jsx
@@ -38,21 +38,22 @@ export default class PredictionDetailTable extends React.Component {
     }
 
     makeRow(rowClassName, chrom, start, end, value, sequence) {
-        let {showChromosomeColumn} = this.props;
+        let {showChromosomeColumn, coreOffset, coreLength} = this.props;
+        let colorDna = <ColorDNA seq={sequence} coreOffset={coreOffset} coreLength={coreLength} />;
         if (showChromosomeColumn) {
             return <tr className={rowClassName}>
                 <td>{chrom}</td>
                 <td>{start}</td>
                 <td>{end}</td>
                 <td>{value}</td>
-                <td><ColorDNA seq={sequence} /></td>
+                <td>{colorDna}</td>
             </tr>;
         } else {
             return <tr className={rowClassName}>
                 <td>{start}</td>
                 <td>{end}</td>
                 <td>{value}</td>
-                <td><ColorDNA seq={sequence} /></td>
+                <td>{colorDna}</td>
             </tr>;
         }
     }

--- a/src/app/prediction/PredictionDetailsDialog.jsx
+++ b/src/app/prediction/PredictionDetailsDialog.jsx
@@ -29,7 +29,7 @@ export default class PredictionDetailsDialog extends React.Component {
 
     render() {
         let {selectedIndexList} = this.state;
-        let {data} = this.props;
+        let {data, coreOffset, coreLength} = this.props;
         if (!data) {
             return <div></div>;
         }
@@ -55,6 +55,9 @@ export default class PredictionDetailsDialog extends React.Component {
             <PredictionDetailTable
                 showChromosomeColumn={false}
                 detailList={detailList}
+                coreOffset={coreOffset}
+                coreLength={coreLength}
+
             />
         </Popup>;
     }

--- a/src/app/prediction/PredictionPage.jsx
+++ b/src/app/prediction/PredictionPage.jsx
@@ -15,7 +15,7 @@ import CustomResultSearch from '../store/CustomResultSearch.js';
 import {CustomSequenceList} from '../store/CustomSequence.js';
 import {ITEMS_PER_PAGE, NUM_PAGE_BUTTONS} from '../store/AppSettings.js'
 import {SEQUENCE_NOT_FOUND} from '../store/Errors.js';
-import {getPreferenceSettings, getFirstGenomeName} from '../store/GenomeData.js';
+import {getPreferenceSettings, getCoreRange, getFirstGenomeName} from '../store/GenomeData.js';
 
 class PredictionPage extends React.Component {
     constructor(props) {
@@ -190,6 +190,10 @@ class PredictionPage extends React.Component {
         let predictionColor = Object.assign({}, this.state.predictionColor);
         Object.assign(predictionColor, preferenceSettings);
 
+        let coreRange = getCoreRange(this.state.genomeData,
+            getFirstGenomeName(this.state.genomeData),
+            this.state.predictionSettings.model);
+
         let searchOperations = {
             search: this.search,
             changePage: this.changePage,
@@ -225,6 +229,7 @@ class PredictionPage extends React.Component {
                                                  predictionColor={predictionColor}
                                                  showBlankWhenEmpty={noSequences}
                                                  jobDates={this.state.jobDates}
+                                                 coreRange={coreRange}
         />;
         return <div>
             <NavBar selected={PREDICTION_NAV.path}/>

--- a/src/app/prediction/PredictionResultsPanel.jsx
+++ b/src/app/prediction/PredictionResultsPanel.jsx
@@ -65,7 +65,7 @@ class PredictionResultsPanel extends React.Component {
 
     render() {
         let {errorMessage, predictionSettings, searchResults, searchDataLoaded, loadingStatusLabel,
-            searchOperations, page, predictionStore, showBlankWhenEmpty, jobDates} = this.props;
+            searchOperations, page, predictionStore, showBlankWhenEmpty, jobDates, coreRange} = this.props;
         let rangeType = false;
         let includeHeatMap = predictionSettings.all === true;
         let showPredictionDetails = Boolean(this.state.predictionData);
@@ -95,6 +95,8 @@ class PredictionResultsPanel extends React.Component {
                                      onRequestClose={this.hidePredictionDetails}
                                      data={this.state.predictionData}
                                      predictionColor={this.props.predictionColor}
+                                     coreOffset={coreRange.coreOffset}
+                                     coreLength={coreRange.coreLength}
             />
         </div>
     }

--- a/src/app/search/ColorDNA.jsx
+++ b/src/app/search/ColorDNA.jsx
@@ -20,24 +20,31 @@ class ColorDNA extends React.Component {
         return color;
     }
 
-    coloredLetterSpan(key, c) {
+    coloredLetterSpan(key, c, underscore) {
         var color = this.determineColor(c.toUpperCase());
         var style = {
             'color': color,
             'fontFamily': FONT_FAMILY,
             'fontSize': FONT_SIZE,
         };
+        if (underscore) {
+            style['borderBottom'] = '1px solid black';
+        }
         return <span key={key} style={style}>{c}</span>;
     }
 
     render() {
-        var seq = this.props.seq;
+        var {seq, coreOffset, coreLength} = this.props;
         var letters = [];
         for (var i = 0; i < seq.length; i++) {
             var c = seq[i];
             // reactjs requires a key for dynamic component lists
             var key = i + "_" + c;
-            letters.push(this.coloredLetterSpan(key, c));
+            let underscore = false;
+            if (coreOffset && coreLength) {
+                underscore = i >= coreOffset && i < coreOffset + coreLength;
+            }
+            letters.push(this.coloredLetterSpan(key, c, underscore));
         }
         return <div>
             {letters}

--- a/src/app/search/PredictionDialog.jsx
+++ b/src/app/search/PredictionDialog.jsx
@@ -49,7 +49,7 @@ class PredictionDialog extends React.Component {
     }
 
     render() {
-        let {data, predictionColor} = this.props;
+        let {data, predictionColor, coreRange} = this.props;
         if (!data) {
             return <div></div>;
         }
@@ -82,6 +82,9 @@ class PredictionDialog extends React.Component {
             <PredictionDetailTable
                 showChromosomeColumn={true}
                 detailList={detailList}
+                coreOffset={coreRange.coreOffset}
+                coreLength={coreRange.coreLength}
+
             />
         </Popup>
     }

--- a/src/app/search/SearchPage.jsx
+++ b/src/app/search/SearchPage.jsx
@@ -11,7 +11,7 @@ import URLBuilder from '../store/URLBuilder.js'
 import PageBatch from '../store/PageBatch.js'
 import {fetchPredictionSettings} from '../store/PredictionSettings.js'
 import {ITEMS_PER_PAGE, NUM_PAGE_BUTTONS} from '../store/AppSettings.js'
-import {getPreferenceSettings} from '../store/GenomeData.js';
+import {getPreferenceSettings, getCoreRange} from '../store/GenomeData.js';
 
 
 class SearchPage extends React.Component {
@@ -121,6 +121,11 @@ class SearchPage extends React.Component {
             this.state.searchSettings.model);
         let predictionColor = Object.assign({}, this.state.predictionColor);
         Object.assign(predictionColor, preferenceSettings);
+
+        let coreRange = getCoreRange(this.state.genomeData,
+            this.state.searchSettings.genome,
+            this.state.searchSettings.model);
+
         let searchOperations = {
             search: this.search,
             changePage: this.changePage,
@@ -166,6 +171,7 @@ class SearchPage extends React.Component {
                                 searchOperations={searchOperations}
                                 predictionColor={predictionColor}
                                 preferenceSettings={preferenceSettings}
+                                coreRange={coreRange}
                             />
                         </div>
 

--- a/src/app/search/SearchResultsPanel.jsx
+++ b/src/app/search/SearchResultsPanel.jsx
@@ -107,7 +107,7 @@ class SearchResultsPanel extends React.Component {
 
     render() {
         let {searchSettings, searchResults, searchDataLoaded, searchOperations,
-            page, predictionStore, predictionColor} = this.props;
+            page, predictionStore, predictionColor, coreRange} = this.props;
         let rangeType = searchSettings.geneList === CUSTOM_RANGES_LIST;
         let includeHeatMap = searchSettings.all === true;
         let listContent = this.makeListContent();
@@ -131,6 +131,7 @@ class SearchResultsPanel extends React.Component {
                               onRequestClose={this.hidePredictionDetails}
                               data={this.state.predictionData}
                               predictionColor={predictionColor}
+                              coreRange={coreRange}
             />
         </div>
     }

--- a/src/app/store/GenomeData.js
+++ b/src/app/store/GenomeData.js
@@ -30,3 +30,19 @@ export function getPreferenceSettings(genomeData, genomeName, modelName) {
         isPreference: false,
     }
 }
+
+export function getCoreRange(genomeData, genomeName, modelName) {
+    let genomeObj = genomeData[genomeName];
+    if (!genomeObj) {
+        return {};
+    }
+    for (let modelObj of genomeObj.models) {
+        if (modelObj.name == modelName) {
+            return {
+                coreOffset: modelObj.core_offset,
+                coreLength: modelObj.core_length,
+            }
+        }
+    }
+    return {}
+}


### PR DESCRIPTION
Adding core_offset and core_length to model preferenceconf.yaml.
Optional tags that allow user to specify where in a prediction the core will be.
There will odd sized predictions in the future so this was not something we can calculate.
Drawing the underline using border so it will be a consistent color(black).

Example for predictionsconf.yaml.

```
    prediction_lists:
      -
        name: "E2F1_0001(JS)"
        ...
        core_offset: 16
        core_length: 4
        ...
```
