### PR TITLE
config gen add genome to track url

### DIFF
--- a/predictionsconf.yaml
+++ b/predictionsconf.yaml
@@ -18,67 +18,67 @@ genome_data:
     fix_script: bigBedToBed
     name: E2F1_0001(JS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19-0001-E2F1-E2F1-bestSVR.model.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0001-E2F1-E2F1-bestSVR.model.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: E2F4_0002(JS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19-0002-E2F4-E2F4-bestSVR.model.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0002-E2F4-E2F4-bestSVR.model.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: E2F1_0003(NS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19-0003-E2F1.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0003-E2F1.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: E2F4_0004(NS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19-0004-E2F4.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0004-E2F4.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: ELK1_0005(NS)
     sort_max_guess: 0.8,
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19-0005-ELK1.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0005-ELK1.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: ETS1_0006(NS)
     sort_max_guess: 0.8,
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19-0006-ETS1.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0006-ETS1.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: HisMadMax_0007(NS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19-0007-HisMadMax.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0007-HisMadMax.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: HisMycMax_0008(NS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19-0008-HisMycMax.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0008-HisMycMax.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: E2F3_0009(NS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19-0009-E2F3.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0009-E2F3.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: GABPA_0010(NS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19-0010-GABPA.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0010-GABPA.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: HisMax_0011(NS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19-0011-HisMax.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0011-HisMax.bb
   trackhub_url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt
 - ftp_files:
   - goldenPath/hg38/database/wgEncodeGencodeBasicV23.txt.gz
@@ -109,67 +109,67 @@ genome_data:
     fix_script: bigBedToBed
     name: E2F1_0001(JS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38-0001-E2F1-E2F1-bestSVR.model.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0001-E2F1-E2F1-bestSVR.model.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: E2F4_0002(JS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38-0002-E2F4-E2F4-bestSVR.model.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0002-E2F4-E2F4-bestSVR.model.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: E2F1_0003(NS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38-0003-E2F1.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0003-E2F1.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: E2F4_0004(NS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38-0004-E2F4.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0004-E2F4.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: ELK1_0005(NS)
     sort_max_guess: 0.8,
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38-0005-ELK1.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0005-ELK1.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: ETS1_0006(NS)
     sort_max_guess: 0.8,
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38-0006-ETS1.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0006-ETS1.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: HisMadMax_0007(NS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38-0007-HisMadMax.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0007-HisMadMax.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: HisMycMax_0008(NS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38-0008-HisMycMax.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0008-HisMycMax.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: E2F3_0009(NS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38-0009-E2F3.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0009-E2F3.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: GABPA_0010(NS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38-0010-GABPA.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0010-GABPA.bb
   - core_length: 4
     core_offset: 8
     fix_script: bigBedToBed
     name: HisMax_0011(NS)
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38-0011-HisMax.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0011-HisMax.bb
   trackhub_url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt
 model_base_url: http://swift.oit.duke.edu/v1/AUTH_gcb/gordan_models
 model_tracks_url: https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks.yaml?dest=/pred_data/models/tracks.yaml

--- a/util/create_conf.py
+++ b/util/create_conf.py
@@ -55,7 +55,7 @@ def create_config_file(trackhub_data, output_filename):
         track_filename = genome_to_track[genome]
         track_data = []
         prediction_lists = []
-        for track, url in trackhub_data.get_track_data(track_filename):
+        for track, url in trackhub_data.get_track_data(genome, track_filename):
             sort_max_guess = SORT_MAX_GUESS.get(track, SORT_MAX_GUESS_DEFAULT)
             core_settings = CORE_SETTINGS.get(track, CORE_SETTINGS_DEFAULT)
             prediction_data = {
@@ -128,7 +128,7 @@ class TrackHubData(object):
                 genome_to_track[genome] = value
         return genome_to_track
 
-    def get_track_data(self, track_filename):
+    def get_track_data(self, genome, track_filename):
         """
         Given track filename return list of tracks, url.
         :param track_filename: filename to lookup track data for.
@@ -141,7 +141,7 @@ class TrackHubData(object):
             if name == 'track':
                 track = value
             if name == 'bigDataUrl':
-                url = self.remote_data.create_url(value)
+                url = self.remote_data.create_url('{}/{}'.format(genome, value))
                 result.append((track, url))
         return result
 


### PR DESCRIPTION
Fixes bug where we had invalid urls for predictions generated via conf_gen downloading from trackhub.
