### PR TITLE
New prediction names

### DIFF
--- a/portal/src/app/common/ModelSelect.jsx
+++ b/portal/src/app/common/ModelSelect.jsx
@@ -5,17 +5,47 @@ import React from 'react';
 import SelectItem from '../common/SelectItem.jsx';
 
 export default class ModelSelect  extends React.Component {
+    /**
+     * Return an option tag based on the mode.
+     * Returns separator if model is undefined.
+     * @param model
+     * @returns {XML}
+     */
     makeOption(model) {
         // Hides numeric portion of names from users.
-        // Additional release should change this dropdown into categories.
-        let userName = model.name.replace(/_.*/, '');
-        return <option key={model.name} value={model.name}>{userName}</option>;
+        // Additional release should change this dropdown into labeled categories.
+        if (model) {
+            let userName = model.name.replace(/_.*/, '');
+            return <option key={model.name} value={model.name}>{userName}</option>;
+        } else {
+            return <option disabled>──────────</option>;
+        }
+    }
+
+    /**
+     * Adds undefined between families so we can create spacers in the dropdown.
+     * @param proteinOptions
+     * @returns {Array}
+     */
+    addSpacers(proteinOptions) {
+        let result = [];
+        if (proteinOptions.length > 0) {
+            let lastFamily = proteinOptions[0].family;
+            for (let model of proteinOptions) {
+                if (model.family != lastFamily) {
+                    result.push(undefined);
+                }
+                result.push(model);
+                lastFamily = model.family;
+            }
+        }
+        return result;
     }
 
     render() {
         let {models, selected, onChange} = this.props;
-
-        let proteinOptions = models.map(this.makeOption);
+        let modelsWithSpacers = [];
+        let proteinOptions = this.addSpacers(models).map(this.makeOption);
         return <SelectItem
             title="Protein/Model:"
             selected={selected}

--- a/pred/config.py
+++ b/pred/config.py
@@ -144,8 +144,9 @@ class GenomeData(object):
             preference_max = prediction_data.get('preference_max', None)
             core_offset = prediction_data.get('core_offset', None)
             core_length = prediction_data.get('core_length', None)
+            family = prediction_data.get('family', None)
             prediction = PredictionSettings(name, url, self.genomename, fix_script, sort_max_guess, type,
-                                            preference_min, preference_max, core_offset, core_length)
+                                            preference_min, preference_max, core_offset, core_length, family)
             self.prediction_lists.append(prediction)
 
     def get_model_types_str(self):
@@ -165,7 +166,7 @@ class GeneInfoSettings(object):
 
 class PredictionSettings(object):
     def __init__(self, name, url, genome, fix_script, sort_max_guess, data_type, preference_min, preference_max,
-                 core_offset, core_length):
+                 core_offset, core_length, family):
         self.name = name
         self.url = url
         self.genome = genome
@@ -176,6 +177,7 @@ class PredictionSettings(object):
         self.preference_max = preference_max
         self.core_offset = core_offset
         self.core_length = core_length
+        self.family = family
 
     def get_data(self):
         """
@@ -189,5 +191,6 @@ class PredictionSettings(object):
             'preference_max': self.preference_max,
             'core_offset': self.core_offset,
             'core_length': self.core_length,
+            'family': self.family
         }
 

--- a/predictionsconf.yaml
+++ b/predictionsconf.yaml
@@ -193,5 +193,5 @@ genome_data:
     sort_max_guess: 0.6
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0011_Runx2.bb
   trackhub_url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt
-model_base_url: http://swift.oit.duke.edu/v1/AUTH_gcb/gordan_models
+model_base_url: https://swift.oit.duke.edu/v1/AUTH_gcb/gordan_models
 model_tracks_url: https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks.yaml?dest=/pred_data/models/tracks.yaml

--- a/predictionsconf.yaml
+++ b/predictionsconf.yaml
@@ -15,58 +15,81 @@ genome_data:
   prediction_lists:
   - core_length: 4
     core_offset: 8
+    family: bHLH
     fix_script: bigBedToBed
-    name: E2F1_0003(NS)
+    name: c-Myc_0001
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0003-E2F1.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0001_c-Myc.bb
   - core_length: 4
     core_offset: 8
+    family: bHLH
     fix_script: bigBedToBed
-    name: E2F4_0004(NS)
+    name: Mad1_0002
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0004-E2F4.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0002_Mad1.bb
   - core_length: 4
     core_offset: 8
+    family: bHLH
     fix_script: bigBedToBed
-    name: ELK1_0005(NS)
-    sort_max_guess: 0.8,
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0005-ELK1.bb
-  - core_length: 4
-    core_offset: 8
-    fix_script: bigBedToBed
-    name: ETS1_0006(NS)
-    sort_max_guess: 0.8,
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0006-ETS1.bb
-  - core_length: 4
-    core_offset: 8
-    fix_script: bigBedToBed
-    name: HisMadMax_0007(NS)
+    name: Max_0003
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0007-HisMadMax.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0003_Max.bb
   - core_length: 4
     core_offset: 8
+    family: ETS
     fix_script: bigBedToBed
-    name: HisMycMax_0008(NS)
+    name: Elk1_0004
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0008-HisMycMax.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0004_Elk1.bb
   - core_length: 4
     core_offset: 8
+    family: ETS
     fix_script: bigBedToBed
-    name: E2F3_0009(NS)
+    name: Ets1_0005
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0009-E2F3.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0005_Ets1.bb
   - core_length: 4
     core_offset: 8
+    family: ETS
     fix_script: bigBedToBed
-    name: GABPA_0010(NS)
+    name: Gabpa_0006
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0010-GABPA.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0006_Gabpa.bb
   - core_length: 4
     core_offset: 8
+    family: E2F
     fix_script: bigBedToBed
-    name: HisMax_0011(NS)
+    name: E2f1_0007
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19-0011-HisMax.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0007_E2f1.bb
+  - core_length: 4
+    core_offset: 8
+    family: E2F
+    fix_script: bigBedToBed
+    name: E2f3_0008
+    sort_max_guess: 0.6
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0008_E2f3.bb
+  - core_length: 4
+    core_offset: 8
+    family: E2F
+    fix_script: bigBedToBed
+    name: E2f4_0009
+    sort_max_guess: 0.6
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0009_E2f4.bb
+  - core_length: 4
+    core_offset: 8
+    family: RUNX
+    fix_script: bigBedToBed
+    name: Runx1_0010
+    sort_max_guess: 0.6
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0010_Runx1.bb
+  - core_length: 4
+    core_offset: 8
+    family: RUNX
+    fix_script: bigBedToBed
+    name: Runx2_0011
+    sort_max_guess: 0.6
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0011_Runx2.bb
   trackhub_url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt
 - ftp_files:
   - goldenPath/hg38/database/wgEncodeGencodeBasicV23.txt.gz
@@ -94,58 +117,81 @@ genome_data:
   prediction_lists:
   - core_length: 4
     core_offset: 8
+    family: bHLH
     fix_script: bigBedToBed
-    name: E2F1_0003(NS)
+    name: c-Myc_0001
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0003-E2F1.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0001_c-Myc.bb
   - core_length: 4
     core_offset: 8
+    family: bHLH
     fix_script: bigBedToBed
-    name: E2F4_0004(NS)
+    name: Mad1_0002
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0004-E2F4.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0002_Mad1.bb
   - core_length: 4
     core_offset: 8
+    family: bHLH
     fix_script: bigBedToBed
-    name: ELK1_0005(NS)
-    sort_max_guess: 0.8,
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0005-ELK1.bb
-  - core_length: 4
-    core_offset: 8
-    fix_script: bigBedToBed
-    name: ETS1_0006(NS)
-    sort_max_guess: 0.8,
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0006-ETS1.bb
-  - core_length: 4
-    core_offset: 8
-    fix_script: bigBedToBed
-    name: HisMadMax_0007(NS)
+    name: Max_0003
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0007-HisMadMax.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0003_Max.bb
   - core_length: 4
     core_offset: 8
+    family: ETS
     fix_script: bigBedToBed
-    name: HisMycMax_0008(NS)
+    name: Elk1_0004
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0008-HisMycMax.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0004_Elk1.bb
   - core_length: 4
     core_offset: 8
+    family: ETS
     fix_script: bigBedToBed
-    name: E2F3_0009(NS)
+    name: Ets1_0005
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0009-E2F3.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0005_Ets1.bb
   - core_length: 4
     core_offset: 8
+    family: ETS
     fix_script: bigBedToBed
-    name: GABPA_0010(NS)
+    name: Gabpa_0006
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0010-GABPA.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0006_Gabpa.bb
   - core_length: 4
     core_offset: 8
+    family: E2F
     fix_script: bigBedToBed
-    name: HisMax_0011(NS)
+    name: E2f1_0007
     sort_max_guess: 0.6
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38-0011-HisMax.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0007_E2f1.bb
+  - core_length: 4
+    core_offset: 8
+    family: E2F
+    fix_script: bigBedToBed
+    name: E2f3_0008
+    sort_max_guess: 0.6
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0008_E2f3.bb
+  - core_length: 4
+    core_offset: 8
+    family: E2F
+    fix_script: bigBedToBed
+    name: E2f4_0009
+    sort_max_guess: 0.6
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0009_E2f4.bb
+  - core_length: 4
+    core_offset: 8
+    family: RUNX
+    fix_script: bigBedToBed
+    name: Runx1_0010
+    sort_max_guess: 0.6
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0010_Runx1.bb
+  - core_length: 4
+    core_offset: 8
+    family: RUNX
+    fix_script: bigBedToBed
+    name: Runx2_0011
+    sort_max_guess: 0.6
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0011_Runx2.bb
   trackhub_url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt
 model_base_url: http://swift.oit.duke.edu/v1/AUTH_gcb/gordan_models
 model_tracks_url: https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks.yaml?dest=/pred_data/models/tracks.yaml

--- a/util/create_conf.yaml
+++ b/util/create_conf.yaml
@@ -1,7 +1,6 @@
 
 # Base url we will download prediciton data from
 DATA_SOURCE_URL: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions
-TRACK_SKIP_IF_CONTAINS: '(JS)'
 
 # Where we save our result to
 CONFIG_FILENAME: ../predictionsconf.yaml

--- a/util/create_conf.yaml
+++ b/util/create_conf.yaml
@@ -25,7 +25,7 @@ CORE_SETTINGS:
   'E2F1_0002(JS)': [16, 4]
 
 MODEL_TRACKS_URL: https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks.yaml?dest=/pred_data/models/tracks.yaml
-MODEL_BASE_URL: http://swift.oit.duke.edu/v1/AUTH_gcb/gordan_models
+MODEL_BASE_URL: https://swift.oit.duke.edu/v1/AUTH_gcb/gordan_models
 
 # Gene lists and other static data for each genome
 GENOME_SPECIFIC_DATA:


### PR DESCRIPTION
Adding family and pulling in new shorter prediction names.
Groups prediction/models by family in dropdown.
Fixes bug where users couldn't download models outside our network.
