### PR TITLE
Runx core

### DIFF
--- a/imadsconf.yaml
+++ b/imadsconf.yaml
@@ -13,22 +13,22 @@ genome_data:
   genome: hg19
   genome_file: goldenPath/hg19/bigZips/hg19.2bit
   prediction_lists:
-  - core_length: 4
-    core_offset: 8
+  - core_length: 6
+    core_offset: 7
     family: bHLH
     fix_script: bigBedToBed
     name: c-Myc_0001
     sort_max_guess: 0.6
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0001_c-Myc.bb
-  - core_length: 4
-    core_offset: 8
+  - core_length: 6
+    core_offset: 7
     family: bHLH
     fix_script: bigBedToBed
     name: Mad1_0002
     sort_max_guess: 0.6
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0002_Mad1.bb
-  - core_length: 4
-    core_offset: 8
+  - core_length: 6
+    core_offset: 7
     family: bHLH
     fix_script: bigBedToBed
     name: Max_0003
@@ -76,14 +76,14 @@ genome_data:
     name: E2f4_0009
     sort_max_guess: 0.6
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0009_E2f4.bb
-  - core_length: 4
+  - core_length: 5
     core_offset: 8
     family: RUNX
     fix_script: bigBedToBed
     name: Runx1_0010
     sort_max_guess: 0.6
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0010_Runx1.bb
-  - core_length: 4
+  - core_length: 5
     core_offset: 8
     family: RUNX
     fix_script: bigBedToBed
@@ -115,22 +115,22 @@ genome_data:
   genome: hg38
   genome_file: goldenPath/hg38/bigZips/hg38.2bit
   prediction_lists:
-  - core_length: 4
-    core_offset: 8
+  - core_length: 6
+    core_offset: 7
     family: bHLH
     fix_script: bigBedToBed
     name: c-Myc_0001
     sort_max_guess: 0.6
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0001_c-Myc.bb
-  - core_length: 4
-    core_offset: 8
+  - core_length: 6
+    core_offset: 7
     family: bHLH
     fix_script: bigBedToBed
     name: Mad1_0002
     sort_max_guess: 0.6
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0002_Mad1.bb
-  - core_length: 4
-    core_offset: 8
+  - core_length: 6
+    core_offset: 7
     family: bHLH
     fix_script: bigBedToBed
     name: Max_0003
@@ -178,14 +178,14 @@ genome_data:
     name: E2f4_0009
     sort_max_guess: 0.6
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0009_E2f4.bb
-  - core_length: 4
+  - core_length: 5
     core_offset: 8
     family: RUNX
     fix_script: bigBedToBed
     name: Runx1_0010
     sort_max_guess: 0.6
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0010_Runx1.bb
-  - core_length: 4
+  - core_length: 5
     core_offset: 8
     family: RUNX
     fix_script: bigBedToBed

--- a/imadsconf.yaml
+++ b/imadsconf.yaml
@@ -39,14 +39,14 @@ genome_data:
     family: ETS
     fix_script: bigBedToBed
     name: Elk1_0004
-    sort_max_guess: 0.6
+    sort_max_guess: 0.8
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0004_Elk1.bb
   - core_length: 4
     core_offset: 8
     family: ETS
     fix_script: bigBedToBed
     name: Ets1_0005
-    sort_max_guess: 0.6
+    sort_max_guess: 0.8
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0005_Ets1.bb
   - core_length: 4
     core_offset: 8
@@ -67,28 +67,28 @@ genome_data:
     family: E2F
     fix_script: bigBedToBed
     name: E2f3_0008
-    sort_max_guess: 0.6
+    sort_max_guess: 0.75
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0008_E2f3.bb
   - core_length: 4
     core_offset: 8
     family: E2F
     fix_script: bigBedToBed
     name: E2f4_0009
-    sort_max_guess: 0.6
+    sort_max_guess: 0.65
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0009_E2f4.bb
   - core_length: 5
     core_offset: 8
     family: RUNX
     fix_script: bigBedToBed
     name: Runx1_0010
-    sort_max_guess: 0.6
+    sort_max_guess: 0.7
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0010_Runx1.bb
   - core_length: 5
     core_offset: 8
     family: RUNX
     fix_script: bigBedToBed
     name: Runx2_0011
-    sort_max_guess: 0.6
+    sort_max_guess: 0.8
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0011_Runx2.bb
   trackhub_url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt
 - ftp_files:
@@ -141,14 +141,14 @@ genome_data:
     family: ETS
     fix_script: bigBedToBed
     name: Elk1_0004
-    sort_max_guess: 0.6
+    sort_max_guess: 0.8
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0004_Elk1.bb
   - core_length: 4
     core_offset: 8
     family: ETS
     fix_script: bigBedToBed
     name: Ets1_0005
-    sort_max_guess: 0.6
+    sort_max_guess: 0.8
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0005_Ets1.bb
   - core_length: 4
     core_offset: 8
@@ -169,28 +169,28 @@ genome_data:
     family: E2F
     fix_script: bigBedToBed
     name: E2f3_0008
-    sort_max_guess: 0.6
+    sort_max_guess: 0.75
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0008_E2f3.bb
   - core_length: 4
     core_offset: 8
     family: E2F
     fix_script: bigBedToBed
     name: E2f4_0009
-    sort_max_guess: 0.6
+    sort_max_guess: 0.65
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0009_E2f4.bb
   - core_length: 5
     core_offset: 8
     family: RUNX
     fix_script: bigBedToBed
     name: Runx1_0010
-    sort_max_guess: 0.6
+    sort_max_guess: 0.7
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0010_Runx1.bb
   - core_length: 5
     core_offset: 8
     family: RUNX
     fix_script: bigBedToBed
     name: Runx2_0011
-    sort_max_guess: 0.6
+    sort_max_guess: 0.8
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0011_Runx2.bb
   trackhub_url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt
 model_base_url: https://swift.oit.duke.edu/v1/AUTH_gcb/gordan_models

--- a/portal/src/app/common/ModelSelect.jsx
+++ b/portal/src/app/common/ModelSelect.jsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import SelectItem from '../common/SelectItem.jsx';
+import {formatModelName} from '../models/Model.js';
 
 export default class ModelSelect  extends React.Component {
     /**
@@ -15,8 +16,8 @@ export default class ModelSelect  extends React.Component {
         // Hides numeric portion of names from users.
         // Additional release should change this dropdown into labeled categories.
         if (model) {
-            let userName = model.name.replace(/_.*/, '');
-            return <option key={model.name} value={model.name}>{userName}</option>;
+            let simplifiedName = formatModelName(model.name);
+            return <option key={model.name} value={model.name}>{simplifiedName}</option>;
         } else {
             return <option disabled>──────────</option>;
         }

--- a/portal/src/app/models/Model.js
+++ b/portal/src/app/models/Model.js
@@ -1,0 +1,7 @@
+export function formatModelName(modelName) {
+    return modelName.replace(/_.*/, '');
+}
+
+export function makeTitleForModelName(modelName, title) {
+    return formatModelName(modelName) + " predictions for " + title;
+}

--- a/portal/src/app/prediction/PredictionDetailsDialog.jsx
+++ b/portal/src/app/prediction/PredictionDetailsDialog.jsx
@@ -3,6 +3,7 @@ import Popup from '../common/Popup.jsx';
 import HeatMap from '../search/HeatMap.jsx';
 import PredictionDetailTable from '../common/PredictionDetailTable.jsx';
 import PredictionDetail from '../models/PredictionDetail.js';
+import {makeTitleForModelName} from '../models/Model.js';
 
 export default class PredictionDetailsDialog extends React.Component {
     constructor(props) {
@@ -29,7 +30,7 @@ export default class PredictionDetailsDialog extends React.Component {
 
     render() {
         let {selectedIndexList} = this.state;
-        let {data, coreOffset, coreLength} = this.props;
+        let {modelName, data, coreOffset, coreLength} = this.props;
         if (!data) {
             return <div></div>;
         }
@@ -40,7 +41,7 @@ export default class PredictionDetailsDialog extends React.Component {
             detailObj.seq = seq;
             detailList.push(detailObj);
         }
-        let title = "Predictions for " + data.title;
+        let title = makeTitleForModelName(modelName, data.title);
         return <Popup isOpen={this.props.isOpen}
                       onRequestClose={this.props.onRequestClose}
                       title={title}>

--- a/portal/src/app/prediction/PredictionResultsPanel.jsx
+++ b/portal/src/app/prediction/PredictionResultsPanel.jsx
@@ -95,6 +95,7 @@ class PredictionResultsPanel extends React.Component {
                                      predictionColor={this.props.predictionColor}
                                      coreOffset={coreRange.coreOffset}
                                      coreLength={coreRange.coreLength}
+                                     modelName={predictionSettings.model}
             />
         </div>
     }

--- a/portal/src/app/search/PredictionDialog.jsx
+++ b/portal/src/app/search/PredictionDialog.jsx
@@ -5,6 +5,7 @@ import PredictionDetailTable from '../common/PredictionDetailTable.jsx';
 import GenomeBrowserURL from '../models/GenomeBrowserURL.js';
 import DnaSequences from '../models/DnaSequences.js';
 import PredictionDetail from '../models/PredictionDetail.js';
+import {makeTitleForModelName} from '../models/Model.js';
 
 class PredictionDialog extends React.Component {
     constructor(props) {
@@ -47,7 +48,7 @@ class PredictionDialog extends React.Component {
     };
 
     render() {
-        let {data, predictionColor, coreRange} = this.props;
+        let {modelName, data, predictionColor, coreRange} = this.props;
         if (!data) {
             return <div></div>;
         }
@@ -61,7 +62,7 @@ class PredictionDialog extends React.Component {
         let genomeBrowserURL = new GenomeBrowserURL('human', this.props.data.trackHubUrl);
         let allRangeGenomeBrowserURL = genomeBrowserURL.getPredictionURL(this.props.data.genome,
             this.props.data.chrom, this.props.data.start, this.props.data.end);
-        let title = "Predictions for " + data.title;
+        let title = makeTitleForModelName(modelName, data.title);
         return <Popup isOpen={this.props.isOpen}
                       onRequestClose={this.props.onRequestClose}
                       title={title}>

--- a/portal/src/app/search/SearchResultsPanel.jsx
+++ b/portal/src/app/search/SearchResultsPanel.jsx
@@ -125,6 +125,7 @@ class SearchResultsPanel extends React.Component {
                               data={this.state.predictionData}
                               predictionColor={predictionColor}
                               coreRange={coreRange}
+                              modelName={searchSettings.model}
             />
         </div>
     }

--- a/portal/src/tests/testModel.js
+++ b/portal/src/tests/testModel.js
@@ -1,0 +1,19 @@
+import {formatModelName, makeTitleForModelName} from './../app/models/Model.js';
+var assert = require('chai').assert;
+
+describe('Model', function () {
+    describe('formatModelName()', function () {
+        it('strips everything after _', function () {
+            assert.equal('c-Myc', formatModelName('c-Myc_0001'));
+            assert.equal('Mad1', formatModelName('Mad1_0002'));
+            assert.equal('Gabpa', formatModelName('Gabpa_0006'));
+        });
+    });
+
+    describe('makeTitleForModelName()', function () {
+        it('should clean model and add title', function () {
+            assert.equal('c-Myc predictions for details', makeTitleForModelName('c-Myc_0001', 'details'));
+            assert.equal('Gabpa predictions for WASH7P', makeTitleForModelName('Gabpa_0006', 'WASH7P'));
+        });
+    });
+});

--- a/util/create_conf.yaml
+++ b/util/create_conf.yaml
@@ -14,8 +14,12 @@ BINDING_MAX_OFFSET: 5000
 # Settings to speed up order by max
 SORT_MAX_GUESS_DEFAULT: 0.6
 SORT_MAX_GUESS:
-  'ELK1_0005(NS)': 0.8,
-  'ETS1_0006(NS)': 0.8,
+  'Elk1_0004': 0.8
+  'Ets1_0005': 0.8
+  'E2f3_0008': 0.75
+  'E2f4_0009': 0.65
+  'Runx1_0010': 0.7
+  'Runx2_0011': 0.8
 
 MODEL_TRACKS_URL: https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks.yaml?dest=/pred_data/models/tracks.yaml
 MODEL_BASE_URL: https://swift.oit.duke.edu/v1/AUTH_gcb/gordan_models

--- a/util/create_conf.yaml
+++ b/util/create_conf.yaml
@@ -17,13 +17,6 @@ SORT_MAX_GUESS:
   'ELK1_0005(NS)': 0.8,
   'ETS1_0006(NS)': 0.8,
 
-# Array of offset, length for determining where the core is in a prediction
-# this causes the underline in the prediction details screen
-CORE_SETTINGS_DEFAULT: [8, 4]
-CORE_SETTINGS:
-  'E2F1_0001(JS)': [16, 4]
-  'E2F1_0002(JS)': [16, 4]
-
 MODEL_TRACKS_URL: https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks.yaml?dest=/pred_data/models/tracks.yaml
 MODEL_BASE_URL: https://swift.oit.duke.edu/v1/AUTH_gcb/gordan_models
 


### PR DESCRIPTION
Calculate core offset and position based on TrackHubGeneroator tracks.yaml fields.
Tweak predictions detail dialog title.
Fix names for sort_max config. Missed this when we renamed the models.
