### PR TITLE
Save per tab settings to sessionStorage

### DIFF
--- a/portal/src/app/models/SessionStorage.js
+++ b/portal/src/app/models/SessionStorage.js
@@ -1,0 +1,15 @@
+// Storage of data that is just for this session.
+// Allows per tab settings to be persisted as user switches between them.
+
+export const PREDICTION_PAGE_KEY = 'predicitonPage';
+export const SEARCH_PAGE_KEY = 'searchPage';
+
+export class SessionStorage {
+    getValue(key) {
+        return JSON.parse(sessionStorage.getItem(key));
+    }
+
+    putValue(key, value) {
+        sessionStorage.setItem(key, JSON.stringify(value));
+    }
+};

--- a/portal/src/app/prediction/UploadSequenceDialog.jsx
+++ b/portal/src/app/prediction/UploadSequenceDialog.jsx
@@ -44,10 +44,6 @@ class UploadSequenceDialog extends React.Component {
         }
     }
 
-    componentWillUnmount() {
-        console.log("UNMOUNT!");
-    }
-
     onSequenceInfo = (sequenceInfo) => {
         this.onChangeTextValue(atob(sequenceInfo.data));
     };

--- a/portal/src/app/search/SearchPage.jsx
+++ b/portal/src/app/search/SearchPage.jsx
@@ -12,6 +12,7 @@ import PageBatch from '../models/PageBatch.js'
 import {fetchPredictionSettings} from '../models/PredictionSettings.js'
 import {ITEMS_PER_PAGE, NUM_PAGE_BUTTONS} from '../models/AppSettings.js'
 import {getPreferenceSettings, getCoreRange} from '../models/GenomeData.js';
+import {SessionStorage, SEARCH_PAGE_KEY} from '../models/SessionStorage.js';
 
 
 class SearchPage extends React.Component {
@@ -20,6 +21,12 @@ class SearchPage extends React.Component {
          let pageBatch = new PageBatch(NUM_PAGE_BUTTONS, ITEMS_PER_PAGE);
          this.predictionStore = new PredictionsStore(pageBatch, new URLBuilder($.ajax));
          let {searchSettings, customListWithoutData} = this.predictionStore.createSettingsFromQueryParams(props.location.query);
+         if (!searchSettings.genome) {
+             let searchSettingsLastVisit = new SessionStorage().getValue(SEARCH_PAGE_KEY);
+             if (searchSettingsLastVisit) {
+                 searchSettings = searchSettingsLastVisit;
+             }
+         }
          let searchDataLoaded = customListWithoutData;
          this.state = {
              genomeData: {},
@@ -50,6 +57,10 @@ class SearchPage extends React.Component {
                 maxBindingOffset: maxBindingOffset,
             }, this.searchFirstPage);
         }.bind(this), this.onError);
+    }
+
+    componentWillUnmount() {
+        new SessionStorage().putValue(SEARCH_PAGE_KEY, this.state.searchSettings);
     }
 
     searchFirstPage = () => {


### PR DESCRIPTION
For SEARCH(SearchPage.jsx) and MAKE PREDICTIONS(PredictionPage.jsx) save of settings when unmounting and restore when we return there.
sessionStorage is per browser tab storage. 
Checking url query before using sessionStorage as the user can paste in other settings.
