### PR TITLE
More Preference Data

### DIFF
--- a/imadsconf.yaml
+++ b/imadsconf.yaml
@@ -101,6 +101,46 @@ genome_data:
     sort_max_guess: 0.8
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0011_Runx2.bb
+  - core_length: 4
+    core_offset: 8
+    family: ETS
+    fix_script: bigBedToBed
+    name: Elk1_vs_Ets1
+    sort_max_guess: 0.6
+    type: PREFERENCE
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_Elk1_0004_vs_Ets1_0005.bb
+  - core_length: 4
+    core_offset: 8
+    family: E2F
+    fix_script: bigBedToBed
+    name: E2f1_vs_E2f4
+    sort_max_guess: 0.6
+    type: PREFERENCE
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_E2f1_0007_vs_E2f4_0009.bb
+  - core_length: 4
+    core_offset: 8
+    family: E2F
+    fix_script: bigBedToBed
+    name: E2f1_vs_E2f3
+    sort_max_guess: 0.6
+    type: PREFERENCE
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_E2f1_0007_vs_E2f3_0008.bb
+  - core_length: 6
+    core_offset: 7
+    family: bHLH
+    fix_script: bigBedToBed
+    name: Mad1_vs_c-Myc
+    sort_max_guess: 0.6
+    type: PREFERENCE
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_Mad1_0002_vs_c-Myc_0001.bb
+  - core_length: 5
+    core_offset: 8
+    family: RUNX
+    fix_script: bigBedToBed
+    name: Runx1_vs_Runx2
+    sort_max_guess: 0.6
+    type: PREFERENCE
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_Runx1_0010_vs_Runx2_0011.bb
   trackhub_url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt
 - ftp_files:
   - goldenPath/hg38/database/wgEncodeGencodeBasicV23.txt.gz
@@ -214,14 +254,48 @@ genome_data:
     sort_max_guess: 0.8
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0011_Runx2.bb
-  - core_length: null
-    core_offset: null
-    family: PREFERENCE
+  - core_length: 4
+    core_offset: 8
+    family: ETS
+    fix_script: bigBedToBed
+    name: Elk1_vs_Ets1
+    sort_max_guess: 0.6
+    type: PREFERENCE
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_Elk1_0004_vs_Ets1_0005.bb
+  - core_length: 4
+    core_offset: 8
+    family: E2F
     fix_script: bigBedToBed
     name: E2f1_vs_E2f4
     sort_max_guess: 0.6
     type: PREFERENCE
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/E2f1_vs_E2f4_GCGC_chr1-2-3.bb
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_E2f1_0007_vs_E2f4_0009.bb
+  - core_length: 4
+    core_offset: 8
+    family: E2F
+    fix_script: bigBedToBed
+    name: E2f1_vs_E2f3
+    sort_max_guess: 0.6
+    type: PREFERENCE
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_E2f1_0007_vs_E2f3_0008.bb
+  - core_length: 6
+    core_offset: 7
+    family: bHLH
+    fix_script: bigBedToBed
+    name: Mad1_vs_c-Myc
+    sort_max_guess: 0.6
+    type: PREFERENCE
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_Mad1_0002_vs_c-Myc_0001.bb
+  - core_length: 5
+    core_offset: 8
+    family: RUNX
+    fix_script: bigBedToBed
+    name: Runx1_vs_Runx2
+    sort_max_guess: 0.6
+    type: PREFERENCE
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_Runx1_0010_vs_Runx2_0011.bb
   trackhub_url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt
 model_base_url: https://swift.oit.duke.edu/v1/AUTH_gcb/gordan_models
-model_tracks_url: https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks.yaml?dest=/pred_data/models/tracks.yaml
+model_tracks_url_list:
+- https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks-predictions.yaml
+- https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks-preferences.yaml

--- a/imadsconf.yaml
+++ b/imadsconf.yaml
@@ -37,6 +37,14 @@ genome_data:
     sort_max_guess: 0.6
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0003_Max.bb
+  - core_length: 6
+    core_offset: 7
+    family: bHLH
+    fix_script: bigBedToBed
+    name: Mad1_vs_c-Myc
+    sort_max_guess: 0.6
+    type: PREFERENCE
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_Mad1_0002_vs_c-Myc_0001.bb
   - core_length: 4
     core_offset: 8
     family: ETS
@@ -63,6 +71,14 @@ genome_data:
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0006_Gabpa.bb
   - core_length: 4
     core_offset: 8
+    family: ETS
+    fix_script: bigBedToBed
+    name: Elk1_vs_Ets1
+    sort_max_guess: 0.6
+    type: PREFERENCE
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_Elk1_0004_vs_Ets1_0005.bb
+  - core_length: 4
+    core_offset: 8
     family: E2F
     fix_script: bigBedToBed
     name: E2f1_0007
@@ -85,30 +101,6 @@ genome_data:
     sort_max_guess: 0.65
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0009_E2f4.bb
-  - core_length: 5
-    core_offset: 8
-    family: RUNX
-    fix_script: bigBedToBed
-    name: Runx1_0010
-    sort_max_guess: 0.7
-    type: PREDICTION
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0010_Runx1.bb
-  - core_length: 5
-    core_offset: 8
-    family: RUNX
-    fix_script: bigBedToBed
-    name: Runx2_0011
-    sort_max_guess: 0.8
-    type: PREDICTION
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0011_Runx2.bb
-  - core_length: 4
-    core_offset: 8
-    family: ETS
-    fix_script: bigBedToBed
-    name: Elk1_vs_Ets1
-    sort_max_guess: 0.6
-    type: PREFERENCE
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_Elk1_0004_vs_Ets1_0005.bb
   - core_length: 4
     core_offset: 8
     family: E2F
@@ -125,14 +117,22 @@ genome_data:
     sort_max_guess: 0.6
     type: PREFERENCE
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_E2f1_0007_vs_E2f3_0008.bb
-  - core_length: 6
-    core_offset: 7
-    family: bHLH
+  - core_length: 5
+    core_offset: 8
+    family: RUNX
     fix_script: bigBedToBed
-    name: Mad1_vs_c-Myc
-    sort_max_guess: 0.6
-    type: PREFERENCE
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_Mad1_0002_vs_c-Myc_0001.bb
+    name: Runx1_0010
+    sort_max_guess: 0.7
+    type: PREDICTION
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0010_Runx1.bb
+  - core_length: 5
+    core_offset: 8
+    family: RUNX
+    fix_script: bigBedToBed
+    name: Runx2_0011
+    sort_max_guess: 0.8
+    type: PREDICTION
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0011_Runx2.bb
   - core_length: 5
     core_offset: 8
     family: RUNX
@@ -190,6 +190,14 @@ genome_data:
     sort_max_guess: 0.6
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0003_Max.bb
+  - core_length: 6
+    core_offset: 7
+    family: bHLH
+    fix_script: bigBedToBed
+    name: Mad1_vs_c-Myc
+    sort_max_guess: 0.6
+    type: PREFERENCE
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_Mad1_0002_vs_c-Myc_0001.bb
   - core_length: 4
     core_offset: 8
     family: ETS
@@ -216,6 +224,14 @@ genome_data:
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0006_Gabpa.bb
   - core_length: 4
     core_offset: 8
+    family: ETS
+    fix_script: bigBedToBed
+    name: Elk1_vs_Ets1
+    sort_max_guess: 0.6
+    type: PREFERENCE
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_Elk1_0004_vs_Ets1_0005.bb
+  - core_length: 4
+    core_offset: 8
     family: E2F
     fix_script: bigBedToBed
     name: E2f1_0007
@@ -238,30 +254,6 @@ genome_data:
     sort_max_guess: 0.65
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0009_E2f4.bb
-  - core_length: 5
-    core_offset: 8
-    family: RUNX
-    fix_script: bigBedToBed
-    name: Runx1_0010
-    sort_max_guess: 0.7
-    type: PREDICTION
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0010_Runx1.bb
-  - core_length: 5
-    core_offset: 8
-    family: RUNX
-    fix_script: bigBedToBed
-    name: Runx2_0011
-    sort_max_guess: 0.8
-    type: PREDICTION
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0011_Runx2.bb
-  - core_length: 4
-    core_offset: 8
-    family: ETS
-    fix_script: bigBedToBed
-    name: Elk1_vs_Ets1
-    sort_max_guess: 0.6
-    type: PREFERENCE
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_Elk1_0004_vs_Ets1_0005.bb
   - core_length: 4
     core_offset: 8
     family: E2F
@@ -278,14 +270,22 @@ genome_data:
     sort_max_guess: 0.6
     type: PREFERENCE
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_E2f1_0007_vs_E2f3_0008.bb
-  - core_length: 6
-    core_offset: 7
-    family: bHLH
+  - core_length: 5
+    core_offset: 8
+    family: RUNX
     fix_script: bigBedToBed
-    name: Mad1_vs_c-Myc
-    sort_max_guess: 0.6
-    type: PREFERENCE
-    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_Mad1_0002_vs_c-Myc_0001.bb
+    name: Runx1_0010
+    sort_max_guess: 0.7
+    type: PREDICTION
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0010_Runx1.bb
+  - core_length: 5
+    core_offset: 8
+    family: RUNX
+    fix_script: bigBedToBed
+    name: Runx2_0011
+    sort_max_guess: 0.8
+    type: PREDICTION
+    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0011_Runx2.bb
   - core_length: 5
     core_offset: 8
     family: RUNX

--- a/imadsconf.yaml
+++ b/imadsconf.yaml
@@ -18,6 +18,8 @@ genome_data:
     family: bHLH
     fix_script: bigBedToBed
     name: c-Myc_0001
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.6
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0001_c-Myc.bb
@@ -26,6 +28,8 @@ genome_data:
     family: bHLH
     fix_script: bigBedToBed
     name: Mad1_0002
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.6
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0002_Mad1.bb
@@ -34,6 +38,8 @@ genome_data:
     family: bHLH
     fix_script: bigBedToBed
     name: Max_0003
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.6
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0003_Max.bb
@@ -42,6 +48,8 @@ genome_data:
     family: bHLH
     fix_script: bigBedToBed
     name: Mad1_vs_c-Myc
+    preference_max: 6.85
+    preference_min: -12.14
     sort_max_guess: 0.6
     type: PREFERENCE
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_Mad1_0002_vs_c-Myc_0001.bb
@@ -50,6 +58,8 @@ genome_data:
     family: ETS
     fix_script: bigBedToBed
     name: Elk1_0004
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.8
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0004_Elk1.bb
@@ -58,6 +68,8 @@ genome_data:
     family: ETS
     fix_script: bigBedToBed
     name: Ets1_0005
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.8
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0005_Ets1.bb
@@ -66,6 +78,8 @@ genome_data:
     family: ETS
     fix_script: bigBedToBed
     name: Gabpa_0006
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.6
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0006_Gabpa.bb
@@ -74,6 +88,8 @@ genome_data:
     family: ETS
     fix_script: bigBedToBed
     name: Elk1_vs_Ets1
+    preference_max: 25.3
+    preference_min: -17.24
     sort_max_guess: 0.6
     type: PREFERENCE
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_Elk1_0004_vs_Ets1_0005.bb
@@ -82,6 +98,8 @@ genome_data:
     family: E2F
     fix_script: bigBedToBed
     name: E2f1_0007
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.6
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0007_E2f1.bb
@@ -90,6 +108,8 @@ genome_data:
     family: E2F
     fix_script: bigBedToBed
     name: E2f3_0008
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.75
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0008_E2f3.bb
@@ -98,6 +118,8 @@ genome_data:
     family: E2F
     fix_script: bigBedToBed
     name: E2f4_0009
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.65
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0009_E2f4.bb
@@ -106,6 +128,8 @@ genome_data:
     family: E2F
     fix_script: bigBedToBed
     name: E2f1_vs_E2f4
+    preference_max: 9.88
+    preference_min: -11.44
     sort_max_guess: 0.6
     type: PREFERENCE
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_E2f1_0007_vs_E2f4_0009.bb
@@ -114,6 +138,8 @@ genome_data:
     family: E2F
     fix_script: bigBedToBed
     name: E2f1_vs_E2f3
+    preference_max: 9.59
+    preference_min: -16.98
     sort_max_guess: 0.6
     type: PREFERENCE
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_E2f1_0007_vs_E2f3_0008.bb
@@ -122,6 +148,8 @@ genome_data:
     family: RUNX
     fix_script: bigBedToBed
     name: Runx1_0010
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.7
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0010_Runx1.bb
@@ -130,6 +158,8 @@ genome_data:
     family: RUNX
     fix_script: bigBedToBed
     name: Runx2_0011
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.8
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg19/hg19_0011_Runx2.bb
@@ -138,10 +168,14 @@ genome_data:
     family: RUNX
     fix_script: bigBedToBed
     name: Runx1_vs_Runx2
+    preference_max: 4.36
+    preference_min: -3.6
     sort_max_guess: 0.6
     type: PREFERENCE
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_Runx1_0010_vs_Runx2_0011.bb
-  trackhub_url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt
+  trackhub_url:
+  - predictions: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt
+  - preferences: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences/hub.txt
 - ftp_files:
   - goldenPath/hg38/database/wgEncodeGencodeBasicV23.txt.gz
   - goldenPath/hg38/database/wgEncodeGencodeCompV23.txt.gz
@@ -171,6 +205,8 @@ genome_data:
     family: bHLH
     fix_script: bigBedToBed
     name: c-Myc_0001
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.6
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0001_c-Myc.bb
@@ -179,6 +215,8 @@ genome_data:
     family: bHLH
     fix_script: bigBedToBed
     name: Mad1_0002
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.6
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0002_Mad1.bb
@@ -187,6 +225,8 @@ genome_data:
     family: bHLH
     fix_script: bigBedToBed
     name: Max_0003
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.6
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0003_Max.bb
@@ -195,6 +235,8 @@ genome_data:
     family: bHLH
     fix_script: bigBedToBed
     name: Mad1_vs_c-Myc
+    preference_max: 6.85
+    preference_min: -12.14
     sort_max_guess: 0.6
     type: PREFERENCE
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_Mad1_0002_vs_c-Myc_0001.bb
@@ -203,6 +245,8 @@ genome_data:
     family: ETS
     fix_script: bigBedToBed
     name: Elk1_0004
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.8
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0004_Elk1.bb
@@ -211,6 +255,8 @@ genome_data:
     family: ETS
     fix_script: bigBedToBed
     name: Ets1_0005
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.8
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0005_Ets1.bb
@@ -219,6 +265,8 @@ genome_data:
     family: ETS
     fix_script: bigBedToBed
     name: Gabpa_0006
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.6
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0006_Gabpa.bb
@@ -227,6 +275,8 @@ genome_data:
     family: ETS
     fix_script: bigBedToBed
     name: Elk1_vs_Ets1
+    preference_max: 25.3
+    preference_min: -17.24
     sort_max_guess: 0.6
     type: PREFERENCE
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_Elk1_0004_vs_Ets1_0005.bb
@@ -235,6 +285,8 @@ genome_data:
     family: E2F
     fix_script: bigBedToBed
     name: E2f1_0007
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.6
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0007_E2f1.bb
@@ -243,6 +295,8 @@ genome_data:
     family: E2F
     fix_script: bigBedToBed
     name: E2f3_0008
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.75
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0008_E2f3.bb
@@ -251,6 +305,8 @@ genome_data:
     family: E2F
     fix_script: bigBedToBed
     name: E2f4_0009
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.65
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0009_E2f4.bb
@@ -259,6 +315,8 @@ genome_data:
     family: E2F
     fix_script: bigBedToBed
     name: E2f1_vs_E2f4
+    preference_max: 9.88
+    preference_min: -11.44
     sort_max_guess: 0.6
     type: PREFERENCE
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_E2f1_0007_vs_E2f4_0009.bb
@@ -267,6 +325,8 @@ genome_data:
     family: E2F
     fix_script: bigBedToBed
     name: E2f1_vs_E2f3
+    preference_max: 9.59
+    preference_min: -16.98
     sort_max_guess: 0.6
     type: PREFERENCE
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_E2f1_0007_vs_E2f3_0008.bb
@@ -275,6 +335,8 @@ genome_data:
     family: RUNX
     fix_script: bigBedToBed
     name: Runx1_0010
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.7
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0010_Runx1.bb
@@ -283,6 +345,8 @@ genome_data:
     family: RUNX
     fix_script: bigBedToBed
     name: Runx2_0011
+    preference_max: ''
+    preference_min: ''
     sort_max_guess: 0.8
     type: PREDICTION
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hg38/hg38_0011_Runx2.bb
@@ -291,10 +355,14 @@ genome_data:
     family: RUNX
     fix_script: bigBedToBed
     name: Runx1_vs_Runx2
+    preference_max: 4.36
+    preference_min: -3.6
     sort_max_guess: 0.6
     type: PREFERENCE
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg38/hg38_Runx1_0010_vs_Runx2_0011.bb
-  trackhub_url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt
+  trackhub_url:
+  - predictions: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt
+  - preferences: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences/hub.txt
 model_base_url: https://swift.oit.duke.edu/v1/AUTH_gcb/gordan_models
 model_tracks_url_list:
 - https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks-predictions.yaml

--- a/portal/src/app/common/SelectItem.css
+++ b/portal/src/app/common/SelectItem.css
@@ -1,5 +1,6 @@
 .SelectItem_select {
     display: inline;
+    font-size: 10pt;
 }
 
 .SelectItem_container {

--- a/portal/src/app/common/StreamInput.css
+++ b/portal/src/app/common/StreamInput.css
@@ -1,0 +1,3 @@
+.StreamInput_input {
+    font-size: 10pt;
+}

--- a/portal/src/app/common/StreamInput.jsx
+++ b/portal/src/app/common/StreamInput.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import StreamValue from '../models/StreamValue.js'
+require('./StreamInput.css');
 
 class StreamInput extends React.Component {
     constructor(props) {
@@ -19,7 +20,7 @@ class StreamInput extends React.Component {
      }
 
     render() {
-        let className = "form-control";
+        let className = "StreamInput_input form-control";
         if (!this.state.isValid) {
             className += " badValue"
         }

--- a/portal/src/app/models/ColorBlender.js
+++ b/portal/src/app/models/ColorBlender.js
@@ -1,6 +1,8 @@
 // Creates CSS color string 'rgb(int, int, int)' given a prediction value and some settings.
 // This is done via: new ColorBlender(...).getColor()
 
+const FLOAT_CUTOOFF = 0.01;
+
 // colors allowed for predictionColor color1 and color2
 export const RED_COLOR_NAME = "red";
 export const GREEN_COLOR_NAME = "green";
@@ -11,10 +13,68 @@ COLOR_RGB[RED_COLOR_NAME]       = [255,   0,   0];
 COLOR_RGB[GREEN_COLOR_NAME]     = [0,   128,   0];
 COLOR_RGB[BLUE_COLOR_NAME]      = [0,     0, 255];
 
+// PREFERENCE_COLORS based on https://github.com/Duke-GCB/TrackHubGenerator/blob/master/cwl/bin/add_itemrgb_column.py
+let PREFERENCE_GRAY = [190, 190, 190];
+/**
+ * Color constants for Red gradient
+ * From Colorbrewer Red 9 http://colorbrewer2.org/?type=sequential&scheme=Reds&n=9
+ */
+let PREFERENCE_REDS = [
+    [255, 245, 240],
+    [254, 224, 210],
+    [252, 187, 161],
+    [252, 146, 114],
+    [251, 106, 74],
+    [239, 59, 44],
+    [203, 24, 29],
+    [165, 15, 21],
+    [103, 0, 13]
+];
+
+/*
+# Color constants for blue gradient
+# Converted to RGB from R Color names
+# plotclr2 = c("midnightblue","steelblue4","steelblue","steelblue3","steelblue2","steelblue1")
+# using chart at http://research.stowers-institute.org/efg/R/Color/Chart/ColorChart.pdf
+
+# midnightblue is the darkest, should be associated with the highest value,
+# and therefore be last.
+*/
+let PREFERENCE_BLUES = [
+    [99, 184, 255],   // steelblue1
+    [92, 172, 238],   // steelblue2
+    [79, 148, 205],   // steelblue3
+    [70, 130, 180],   // steelblue
+    [54, 100, 139],   // steelblue4
+    [25, 25, 112]    // midnightblue
+];
+
+/**
+ * Color constants for green gradient
+ * http://colorbrewer2.org/?type=sequential&scheme=Reds&n=9#type=sequential&scheme=Greens&n=9
+ */
+let PREFERENCE_GREENS = [
+    [247,252,245],
+    [229,245,224],
+    [199,233,192],
+    [161,217,155],
+    [116,196,118],
+    [65,171,93],
+    [35,139,69],
+    [0,109,44],
+    [0,68,27]
+];
+
+let PREF_ARRAY_LOOKUP = {};
+PREF_ARRAY_LOOKUP[RED_COLOR_NAME] = PREFERENCE_REDS;
+PREF_ARRAY_LOOKUP[GREEN_COLOR_NAME] = PREFERENCE_GREENS;
+PREF_ARRAY_LOOKUP[BLUE_COLOR_NAME] = PREFERENCE_BLUES;
+
 export default class ColorBlender {
-    constructor(value, predictionColor) {
+    constructor(value, predictionColor, isPreference) {
         this.value = value;
         this.predictionColor = predictionColor;
+        this.isPreference = isPreference;
     }
 
     isNegative() {
@@ -46,9 +106,90 @@ export default class ColorBlender {
 
     getColor() {
         let colorName = this.determineColorName();
+        if (this.isPreference) {
+            return this.getPreferenceColor(colorName);
+        }
         let colorRGB = COLOR_RGB[colorName];
-        let colorValues = ColorBlender.interpolateRGB(colorRGB[0], colorRGB[1], colorRGB[2], this.getScaledValue());
+        let zeroColor = [255, 255, 255];
+        let colorValues = ColorBlender.interpolateRGB(zeroColor, colorRGB, this.getScaledValue());
         return this.getRGBString(colorValues);
+    }
+
+    getPreferenceArray() {
+        let colorName = this.determineColorName();
+        return PREF_ARRAY_LOOKUP[colorName];
+    }
+
+    getPreferenceColor(colorName) {
+        let value = this.getScaledValue();
+        let colorRGB = PREFERENCE_GRAY;
+        if (value > 0.001 || value < -0.001) {
+            let gradientArray = this.getPreferenceArray();
+            let slots = ColorBlender.determineSlots(value, gradientArray.length);
+            colorRGB = gradientArray[slots[0]];
+            if (slots[0] != slots[1]) {
+                let zeroColor = gradientArray[slots[0]];
+                let oneColor = gradientArray[slots[1]];
+                //need to scale value for the two slots
+                let slotScaledValue = ColorBlender.scaleValueForSlot(slots[0], gradientArray.length, value);
+                let blendedColor = ColorBlender.interpolateRGB(zeroColor, oneColor, slotScaledValue);
+                return this.getRGBString(blendedColor);
+            }
+        }
+        return this.getRGBString({
+            'r': colorRGB[0],
+            'g': colorRGB[1],
+            'b': colorRGB[2]
+        });
+    }
+
+    /**
+     * Give a value range 0.0 to 1.0 pick a pair of indexes into an array of size numItems
+     * to allow blending the values at these two indexes.
+     * @param value value we will
+     * @param numItems int: number of items in an array
+     * @returns [int, int] indexes into an array of numItems length
+     */
+    static determineSlots(value, numItems) {
+        value = Math.abs(value);
+        let lastSlot = numItems - 1;
+        if (value >= 1.0) {
+            return [lastSlot, lastSlot];
+        }
+        if (value <= 0.0) {
+            return [0, 0];
+        }
+        let numPairs = numItems - 1;
+        let slot = Math.round(value * numPairs);
+        let secondSlot = slot + 1;
+        if (secondSlot >= numItems) {
+            secondSlot = slot;
+        }
+        return [slot, secondSlot]
+    }
+
+    /**
+     * Given a slotNum(array index) and number of items in array determine
+     * a value between 0.0 -> 1.0 representing that stot
+     * @param slotNum int index into the array
+     * @param numItems int number items in the array
+     */
+    static determineSlotValue(slotNum, numItems) {
+        return slotNum * (1.0 / numItems);
+    }
+
+    /**
+     * Given an index, the number of items in an array and a value 0.0 -> 1.0
+     * scale the value based on the position in the array.
+     * @param slotNum int index into the array
+     * @param numItems  int number items in the array
+     * @param value value to scale
+     * @returns {number} scaled value based on the slot specified
+     */
+    static scaleValueForSlot(slotNum, numItems, value) {
+        value = Math.abs(value);
+        let slotValue = ColorBlender.determineSlotValue(slotNum, numItems);
+        return Math.abs(value - slotValue) * numItems;
     }
 
     getRGBString(rgbValues) {
@@ -56,18 +197,28 @@ export default class ColorBlender {
         return "rgb(" + r + "," + g + "," + b + ")";
     }
 
-    // zeroColor it is always higher than oneColorInt
-    static interpolate(zeroColorInt, oneColorInt, value) {
-        let diff = zeroColorInt - oneColorInt;
-        return zeroColorInt - parseInt(Math.abs(value) * diff);
+    /**
+     * Interpolates between zeroColor and oneColor based on value.
+     * @param zeroColor int color for when value == 0
+     * @param oneColor int color for when value == 1
+     * @param value value between 0.0 and 1.0 to scale between zeroColor and oneColor
+     * @returns {int} between zeroColor and oneColor
+     */
+    static interpolate(zeroColor, oneColor, value) {
+        if (value < 0) {
+            value *= -1;
+        }
+        let zeroColorInt = parseInt(zeroColor);
+        let oneColorInt = parseInt(oneColor);
+        let diff = oneColorInt - zeroColorInt;
+        return Math.round(zeroColorInt  +  (value * diff));
     }
 
-    static interpolateRGB(r, g, b, value) {
-        let zeroColorInt = 255;
+    static interpolateRGB(lowColorArray, highColorArray, value) {
         return {
-            r: ColorBlender.interpolate(zeroColorInt, r, value),
-            g: ColorBlender.interpolate(zeroColorInt, g, value),
-            b: ColorBlender.interpolate(zeroColorInt, b, value),
+            r: ColorBlender.interpolate(lowColorArray[0], highColorArray[0], value),
+            g: ColorBlender.interpolate(lowColorArray[1], highColorArray[1], value),
+            b: ColorBlender.interpolate(lowColorArray[2], highColorArray[2], value)
         }
     }
 }

--- a/portal/src/app/models/ColorBlender.js
+++ b/portal/src/app/models/ColorBlender.js
@@ -1,7 +1,8 @@
 // Creates CSS color string 'rgb(int, int, int)' given a prediction value and some settings.
 // This is done via: new ColorBlender(...).getColor()
 
-const FLOAT_CUTOOFF = 0.01;
+const POS_FLOAT_CUTOOFF = 0.001;
+const NEG_FLOAT_CUTOOFF = -0.001;
 
 // colors allowed for predictionColor color1 and color2
 export const RED_COLOR_NAME = "red";
@@ -123,7 +124,7 @@ export default class ColorBlender {
     getPreferenceColor(colorName) {
         let value = this.getScaledValue();
         let colorRGB = PREFERENCE_GRAY;
-        if (value > 0.001 || value < -0.001) {
+        if (value > POS_FLOAT_CUTOOFF || value < NEG_FLOAT_CUTOOFF) {
             let gradientArray = this.getPreferenceArray();
             let slots = ColorBlender.determineSlots(value, gradientArray.length);
             colorRGB = gradientArray[slots[0]];

--- a/portal/src/app/models/GenomeBrowserURL.js
+++ b/portal/src/app/models/GenomeBrowserURL.js
@@ -6,9 +6,9 @@ const PREDICTION_VIEW_OFFSET = 20;
 const UCSC_START_OFFSET = 1;
 
 class GenomeBrowserURL {
-    constructor(org = 'human', trackHubUrl = '') {
+    constructor(org = 'human', trackHubUrlList = []) {
         this.org = org;
-        this.trackHubUrl = trackHubUrl;
+        this.trackHubUrlList = trackHubUrlList;
     }
 
     makePosition(chrom, start, end) {
@@ -16,20 +16,34 @@ class GenomeBrowserURL {
         return chrom + ":" + actualStart  + '-' + end;
     }
 
-    getPredictionURL(db, chrom, start, end) {
+    getPredictionURL(db, chrom, start, end, isPreference) {
         let actualStart = parseInt(start) - PREDICTION_VIEW_OFFSET;
         let actualEnd = parseInt(end) + PREDICTION_VIEW_OFFSET;
-        return this.get(db, this.makePosition(chrom, actualStart, actualEnd));
+        let trackHubUrl = this.getTrackHubUrl(isPreference);
+        return this.get(db, this.makePosition(chrom, actualStart, actualEnd), trackHubUrl);
     }
 
-    getGeneURL(db, chrom, start, end) {
-        return this.get(db, this.makePosition(chrom, start, end));
+    getTrackHubUrl(isPreference) {
+        for (let trackHubUrl of this.trackHubUrlList) {
+            if (isPreference && trackHubUrl.preferences) {
+                return trackHubUrl.preferences;
+            }
+            if (!isPreference && trackHubUrl.predictions) {
+                return trackHubUrl.predictions;
+            }
+        }
+        return '';
     }
 
-    get(db, position) {
+    getGeneURL(db, chrom, start, end, isPreference) {
+        let trackHubUrl = this.getTrackHubUrl(isPreference);
+        return this.get(db, this.makePosition(chrom, start, end), trackHubUrl);
+    }
+
+    get(db, position, trackHubUrl) {
         let url = BASE_URL + '?org=' + this.org + '&db=' + db + '&position=' + position;
-        if (this.trackHubUrl) {
-            url += '&hubUrl=' + this.trackHubUrl;
+        if (trackHubUrl) {
+            url += '&hubUrl=' + trackHubUrl;
         }
         return url;
     }

--- a/portal/src/app/models/HeatMapData.js
+++ b/portal/src/app/models/HeatMapData.js
@@ -43,6 +43,7 @@ class HeatMapData {
     static buildCellArray(chrom, inputArray, props, predictionColor) {
         let results = [];
         let idx = 0;
+        let isPreference = predictionColor.isPreference;
         let sortedInputArray = inputArray.slice();
         sortedInputArray.sort(sortByAbsValue);
         for (let item of sortedInputArray) {
@@ -59,7 +60,8 @@ class HeatMapData {
                 value: item.value,
             };
             let hmd = new HeatMapData(chrom, data, props.xOffset, props.includeTitle, itemWidth);
-            let color = new ColorBlender(data.value, predictionColor).getColor();
+
+            let color = new ColorBlender(data.value, predictionColor, isPreference).getColor();
             results.push({
                 color: color,
                 x: hmd.getX(props.scale, props.strand, props.xOffsetEnd),

--- a/portal/src/app/search/HeatMap.jsx
+++ b/portal/src/app/search/HeatMap.jsx
@@ -38,6 +38,7 @@ class HeatMap extends React.Component {
 
     getHeatRects(scale) {
         let {data, predictionColor} = this.props;
+        let isPreference = predictionColor.isPreference;
         let result = [];
         let cells = HeatMapData.buildCellArray(data.chrom, data.values, {
             xOffset: this.props.data.start,
@@ -49,12 +50,12 @@ class HeatMap extends React.Component {
             itemWidth: this.props.data.itemWidth
         }, predictionColor);
         for (let i = 0; i < cells.length; i++) {
-            result.push(this.makeHeatRect(i, cells[i]));
+            result.push(this.makeHeatRect(i, cells[i], isPreference));
         }
         return result;
     }
 
-    makeHeatRect(idx, heatCell) {
+    makeHeatRect(idx, heatCell, isPreference) {
         let title = [];
         if (heatCell.title) {
             title = <title>{heatCell.title}</title>;
@@ -62,7 +63,7 @@ class HeatMap extends React.Component {
         let url = '';
         if (!this.props.showDetailsOnClick) {
             url = this.genomeBrowserURL.getPredictionURL(this.props.data.genome, this.props.data.chrom,
-                heatCell.start, heatCell.end);
+                heatCell.start, heatCell.end, isPreference);
         }
         return <g key={"heat_cell" + idx} >
             {title}
@@ -74,7 +75,7 @@ class HeatMap extends React.Component {
 
     drillDown = (evt) => {
         let {setSelectedIndex} = this.props;
-        if (this.genomeBrowserURL.trackHubUrl) {
+        if (this.genomeBrowserURL.trackHubUrlList) {
             let url = evt.target.getAttribute('data-url');
             window.open(url);
         } else {
@@ -87,10 +88,11 @@ class HeatMap extends React.Component {
     };
 
     viewInGenomeBrowser = () => {
-        let {setSelectedIndex} = this.props;
-        if (this.genomeBrowserURL.trackHubUrl) {
+        let {setSelectedIndex, predictionColor} = this.props;
+        if (this.genomeBrowserURL.trackHubUrlList) {
             let data = this.props.data;
-            window.open(this.genomeBrowserURL.getGeneURL(data.genome, data.chrom, data.start, data.end));
+            window.open(this.genomeBrowserURL.getGeneURL(data.genome, data.chrom, data.start, data.end,
+                predictionColor.isPreference));
         } else {
             if (setSelectedIndex) {
                 setSelectedIndex(undefined);

--- a/portal/src/app/search/PredictionDialog.jsx
+++ b/portal/src/app/search/PredictionDialog.jsx
@@ -62,7 +62,7 @@ class PredictionDialog extends React.Component {
         }
         let genomeBrowserURL = new GenomeBrowserURL('human', this.props.data.trackHubUrl);
         let allRangeGenomeBrowserURL = genomeBrowserURL.getPredictionURL(this.props.data.genome,
-            this.props.data.chrom, this.props.data.start, this.props.data.end);
+            this.props.data.chrom, this.props.data.start, this.props.data.end, predictionColor.isPreference);
         let title = makeTitleForModelName(modelName, data.title);
         return <Popup isOpen={this.props.isOpen}
                       onRequestClose={this.props.onRequestClose}

--- a/portal/src/tests/testColorBlender.js
+++ b/portal/src/tests/testColorBlender.js
@@ -43,55 +43,135 @@ describe('ColorBlender', function () {
     });
 
     describe('getColor()', function () {
-        it('works for red and blue combination', function () {
+        it('works for red and blue combination for prediction data', function () {
             let predictionColor = {
                 color1: RED_COLOR_NAME,
                 color2: BLUE_COLOR_NAME,
             };
             //test red values
-            assert.equal('rgb(255,0,0)', new ColorBlender(1.0, predictionColor).getColor());
-            assert.equal('rgb(255,128,128)', new ColorBlender(0.5, predictionColor).getColor());
-            assert.equal('rgb(255,255,255)', new ColorBlender(0.0, predictionColor).getColor());
+            assert.equal('rgb(255,0,0)', new ColorBlender(1.0, predictionColor, false).getColor());
+            assert.equal('rgb(255,128,128)', new ColorBlender(0.5, predictionColor, false).getColor());
+            assert.equal('rgb(255,255,255)', new ColorBlender(0.0, predictionColor, false).getColor());
             //test blue values
-            assert.equal('rgb(0,0,255)', new ColorBlender(-1.0, predictionColor).getColor());
-            assert.equal('rgb(128,128,255)', new ColorBlender(-0.5, predictionColor).getColor());
+            assert.equal('rgb(0,0,255)', new ColorBlender(-1.0, predictionColor, false).getColor());
+            assert.equal('rgb(128,128,255)', new ColorBlender(-0.5, predictionColor, false).getColor());
+        });
 
+        it('works for red and blue combination for preference data', function () {
+            let predictionColor = {
+                color1: RED_COLOR_NAME,
+                color2: BLUE_COLOR_NAME,
+            };
+            let deepRed = 'rgb(103,0,13)';
+            assert.equal(deepRed, new ColorBlender(1.0, predictionColor, true).getColor());
+
+            let zeroGray = 'rgb(190,190,190)';
+            assert.equal(zeroGray, new ColorBlender(0.0, predictionColor, true).getColor());
+
+            let midnightBlue = 'rgb(25,25,112)';
+            assert.equal(midnightBlue, new ColorBlender(-1.0, predictionColor, true).getColor());
+        });
+    });
+
+    describe('determineSlots()', function() {
+        it('returns appropriate pairs for ten items', function () {
+            let values = [
+                { 'expected': [0,0], 'value': 0.0, 'numItems': 10},
+                { 'expected': [0,1], 'value': 0.05, 'numItems': 10},
+                { 'expected': [1,2], 'value': 0.1, 'numItems': 10},
+                { 'expected': [2,3], 'value': 0.2, 'numItems': 10},
+                { 'expected': [3,4], 'value': 0.3, 'numItems': 10},
+                { 'expected': [5,6], 'value': 0.5, 'numItems': 10},
+                { 'expected': [8,9], 'value': 0.9, 'numItems': 10},
+                { 'expected': [9,9], 'value': 1.0, 'numItems': 10},
+                { 'expected': [9,9], 'value': 2.0, 'numItems': 10}
+            ];
+            for (let data of values) {
+                assert.deepEqual(data.expected, ColorBlender.determineSlots(data.value, data.numItems));
+            }
+        });
+        it('returns appropriate pairs for six items', function () {
+            assert.deepEqual([5, 5], ColorBlender.determineSlots(-0.972, 6));
+        });
+    });
+
+    describe('determineSlotValue()', function () {
+        it('returns expected values', function () {
+            let values = [
+                { 'expected': '0.0', 'slotNum': 0, 'numItems': 10},
+                { 'expected': '0.1', 'slotNum': 1, 'numItems': 10},
+                { 'expected': '0.2', 'slotNum': 2, 'numItems': 10},
+                { 'expected': '0.3', 'slotNum': 3, 'numItems': 10},
+                { 'expected': '0.4', 'slotNum': 4, 'numItems': 10},
+                { 'expected': '0.9', 'slotNum': 9, 'numItems': 10},
+
+            ];
+            for (let data of values) {
+                let result = ColorBlender.determineSlotValue(data.slotNum, data.numItems);
+                assert.deepEqual(data.expected, result.toFixed(1));
+            }
         });
     });
 
     describe('interpolate()', function () {
         it('work with 255 0 range', function () {
-            assert.equal(255, ColorBlender.interpolate(255, 0, 0.0));
-            assert.equal(128, ColorBlender.interpolate(255, 0, 0.5));
-            assert.equal(0, ColorBlender.interpolate(255, 0, 1.0));
+            let values = [
+                { 'expected': 255, 'input': 0.0 },
+                { 'expected': 128, 'input': 0.5 },
+                { 'expected': 0,   'input': 1.0 },
+            ];
+            for (let data of values) {
+                assert.equal(data.expected, ColorBlender.interpolate(255, 0, data.input));
+            }
+        });
+        it('work with 0 255 range', function () {
+            let values = [
+                { 'expected': 0, 'input': 0.0 },
+                { 'expected': 128, 'input': 0.5 },
+                { 'expected': 255,   'input': 1.0 },
+            ];
+            for (let data of values) {
+                assert.equal(data.expected, ColorBlender.interpolate(0, 255, data.input));
+            }
+        });
+        it('work with 128 0 range', function () {
+            let values = [
+                { 'expected': 128, 'input': 0.0 },
+                { 'expected': 64, 'input': 0.5 },
+                { 'expected': 0,   'input': 1.0 },
+            ];
+            for (let data of values) {
+                assert.equal(data.expected, ColorBlender.interpolate(128, 0, data.input));
+            }
         });
     });
 
     describe('interpolateRGB()', function () {
+        let zeroColorAry = [255, 255, 255];
         it('red with 0 value is white', function () {
             let white = { r: 255, g: 255, b: 255 };
-            assert.deepEqual(white, ColorBlender.interpolateRGB(255, 0, 0, 0.0));
+            assert.deepEqual(white, ColorBlender.interpolateRGB(zeroColorAry, [255, 0, 0], 0.0));
         });
         it('red with 1 value is red', function () {
             let red = { r: 255, g: 0, b: 0 };
-            assert.deepEqual(red, ColorBlender.interpolateRGB(255, 0, 0, 1.0));
+            assert.deepEqual(red, ColorBlender.interpolateRGB(zeroColorAry, [255, 0, 0], 1.0));
         });
         it('red with 0.5 value is pink', function () {
             let pink = { r: 255, g: 128, b: 128 };
-            assert.deepEqual(pink, ColorBlender.interpolateRGB(255, 0, 0, 0.5));
+            assert.deepEqual(pink, ColorBlender.interpolateRGB(zeroColorAry, [255, 0, 0], 0.5));
         });
 
         it('blue with 0 value is white', function () {
             let white = { r: 255, g: 255, b: 255 };
-            assert.deepEqual(white, ColorBlender.interpolateRGB(0, 0, 255, 0.0));
+            assert.deepEqual(white, ColorBlender.interpolateRGB(zeroColorAry, [0, 0, 255], 0.0));
         });
         it('blue with 1 value is blue', function () {
             let blue = { r: 0, g: 0, b: 255 };
-            assert.deepEqual(blue, ColorBlender.interpolateRGB(0, 0, 255, 1.0));
+            assert.deepEqual(blue, ColorBlender.interpolateRGB(zeroColorAry, [0, 0, 255], 1.0));
         });
         it('blue with 0.5 value is light blue', function () {
             let lightBlue = { r: 128, g: 128, b: 255 };
-            assert.deepEqual(lightBlue, ColorBlender.interpolateRGB(0, 0, 255, 0.5));
+            assert.deepEqual(lightBlue, ColorBlender.interpolateRGB(zeroColorAry, [0, 0, 255], 0.5));
         });
     });
 });

--- a/pred/config.py
+++ b/pred/config.py
@@ -50,7 +50,7 @@ class DBConfig(object):
 class Config(object):
     def __init__(self, data, dbconfig):
         self.binding_max_offset = data.get('binding_max_offset', DEFAULT_MAX_BINDING_OFFSET)
-        self.model_tracks_url = data.get('model_tracks_url', None)
+        self.model_tracks_url_list = data.get('model_tracks_url_list', None)
         self.model_base_url = data.get('model_base_url')
         self.download_dir = data['download_dir']
         self.genome_data_list = []

--- a/pred/config.py
+++ b/pred/config.py
@@ -50,7 +50,7 @@ class DBConfig(object):
 class Config(object):
     def __init__(self, data, dbconfig):
         self.binding_max_offset = data.get('binding_max_offset', DEFAULT_MAX_BINDING_OFFSET)
-        self.model_tracks_url_list = data.get('model_tracks_url_list', [])
+        self.model_tracks_url = data.get('model_tracks_url', None)
         self.model_base_url = data.get('model_base_url')
         self.download_dir = data['download_dir']
         self.genome_data_list = []

--- a/pred/config.py
+++ b/pred/config.py
@@ -50,7 +50,7 @@ class DBConfig(object):
 class Config(object):
     def __init__(self, data, dbconfig):
         self.binding_max_offset = data.get('binding_max_offset', DEFAULT_MAX_BINDING_OFFSET)
-        self.model_tracks_url = data.get('model_tracks_url', None)
+        self.model_tracks_url_list = data.get('model_tracks_url_list', [])
         self.model_base_url = data.get('model_base_url')
         self.download_dir = data['download_dir']
         self.genome_data_list = []

--- a/pred/load/loaddatabase.py
+++ b/pred/load/loaddatabase.py
@@ -14,7 +14,6 @@ from pred.load.postgres import PostgresConnection, CopyCommand
 from psycopg2 import OperationalError
 
 SQL_TEMPLATE_DIR = 'sql_templates'
-METADATA_FILE_DESC = 'Settings for all models'
 METADATA_GROUP_NAME = 'Metadata'
 
 
@@ -74,9 +73,12 @@ def create_sql_for_model_files(config, sql_builder):
         description = details['description']
         sql_builder.insert_data_source(url, description, 'model', local_path, group_name)
     model_files = ModelFiles(config)
-    local_tracks_filename = model_files.get_local_tracks_filename()
-    sql_builder.insert_data_source(config.model_tracks_url, METADATA_FILE_DESC, 'model',
-                                   local_tracks_filename, METADATA_GROUP_NAME)
+
+    for model_tracks_url in config.model_tracks_url_list:
+        local_tracks_filename = model_files.get_local_path_for_url(model_tracks_url)
+        name = model_files.get_model_track_name(model_tracks_url)
+        sql_builder.insert_data_source(model_tracks_url, name, 'model',
+                                       local_tracks_filename, METADATA_GROUP_NAME)
 
 
 def create_pipeline_for_genome_version(database_loader):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ CONFIG_DATA = {
     "binding_max_offset": 5000,
     "download_dir": "/tmp/pred_data",
     'model_base_url': 'someModelURL',
-    'model_tracks_url': 'someTracksURL',
+    'model_tracks_url_list': ['someTracksURL'],
     "genome_data": [
         {
             "genome": "hg19",
@@ -45,7 +45,7 @@ class TestConfigLoading(TestCase):
         self.assertEqual(5000, config.binding_max_offset)
         self.assertEqual('/tmp/pred_data', config.download_dir)
         self.assertEqual('someModelURL', config.model_base_url)
-        self.assertEqual('someTracksURL', config.model_tracks_url)
+        self.assertEqual(['someTracksURL'], config.model_tracks_url_list)
         genomes_setup = config.get_genomes_setup()
         self.assertEqual(1, len(genomes_setup))
         hg19 = genomes_setup['hg19']

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -53,7 +53,7 @@ CONFIG_DATA = {
             ]
         }
     ],
-    'model_tracks_url': 'https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks.yaml?dest=/pred_data/models/tracks.yaml',
+    'model_tracks_url_list': ['https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks-predictions.yaml'],
 }
 
 FILENAME_TO_SQL = {

--- a/util/create_conf.yaml
+++ b/util/create_conf.yaml
@@ -8,6 +8,8 @@ DATA_SOURCES:
    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences/
    model_tracks_url: https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks-preferences.yaml
 
+MODEL_FAMILY_ORDER: [bHLH, ETS, E2F, RUNX]
+
 # Where we save our result to
 CONFIG_FILENAME: ../imadsconf.yaml
 

--- a/util/create_conf.yaml
+++ b/util/create_conf.yaml
@@ -1,4 +1,7 @@
 
+
+DOWNLOAD_DIR: /tmp/pred_data
+
 # Base urls we will download prediction/preference data from
 DATA_SOURCES:
  - type: PREDICTION
@@ -29,13 +32,56 @@ SORT_MAX_GUESS:
   'Runx1_0010': 0.7
   'Runx2_0011': 0.8
 
+PREF_MIN_MAX:
+- genome: hg38
+  name: E2f1_0007_vs_E2f3_0008
+  pref_min: -16.98
+  pref_max: 9.59
+- genome: hg38
+  name: E2f1_0007_vs_E2f4_0009
+  pref_min: -11.44
+  pref_max: 9.88
+- genome: hg38
+  name: Elk1_0004_vs_Ets1_0005
+  pref_min: -17.24
+  pref_max: 25.3
+- genome: hg38
+  name: Mad1_0002_vs_c-Myc_0001
+  pref_min: -12.14
+  pref_max: 6.85
+- genome: hg38
+  name: Runx1_0010_vs_Runx2_0011
+  pref_min: -3.6
+  pref_max: 4.36
+- genome: hg19
+  name: E2f1_0007_vs_E2f3_0008
+  pref_min: -16.98
+  pref_max: 9.59
+- genome: hg19
+  name: E2f1_0007_vs_E2f4_0009
+  pref_min: -11.44
+  pref_max: 9.88
+- genome: hg19
+  name: Elk1_0004_vs_Ets1_0005
+  pref_min: -17.24
+  pref_max: 25.3
+- genome: hg19
+  name: Mad1_0002_vs_c-Myc_0001
+  pref_min: -12.14
+  pref_max: 6.85
+- genome: hg19
+  name: Runx1_0010_vs_Runx2_0011
+  pref_min: -3.6
+  pref_max: 4.36
 
 MODEL_BASE_URL: https://swift.oit.duke.edu/v1/AUTH_gcb/gordan_models
 
 # Gene lists and other static data for each genome
 GENOME_SPECIFIC_DATA:
   hg19:
-    trackhub_url: "http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt"
+    trackhub_url:
+      - predictions: "http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt"
+      - preferences: "http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences/hub.txt"
     ftp_files:
       - "goldenPath/hg19/database/knownGene.txt.gz"
       - "goldenPath/hg19/database/kgXref.txt.gz"
@@ -47,7 +93,9 @@ GENOME_SPECIFIC_DATA:
         common_lookup_table: "kgxref"
         common_lookup_table_field: "kgid"
   hg38:
-    trackhub_url: "http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt"
+    trackhub_url:
+      - predictions: "http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt"
+      - preferences: "http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences/hub.txt"
     ftp_files:
       - "goldenPath/hg38/database/wgEncodeGencodeBasicV23.txt.gz"
       - "goldenPath/hg38/database/wgEncodeGencodeCompV23.txt.gz"

--- a/util/create_conf.yaml
+++ b/util/create_conf.yaml
@@ -3,8 +3,10 @@
 DATA_SOURCES:
  - type: PREDICTION
    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions
+   model_tracks_url: https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks-predictions.yaml
  - type: PREFERENCE
    url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences/
+   model_tracks_url: https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks-preferences.yaml
 
 # Where we save our result to
 CONFIG_FILENAME: ../imadsconf.yaml
@@ -25,7 +27,7 @@ SORT_MAX_GUESS:
   'Runx1_0010': 0.7
   'Runx2_0011': 0.8
 
-MODEL_TRACKS_URL: https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks.yaml?dest=/pred_data/models/tracks.yaml
+
 MODEL_BASE_URL: https://swift.oit.duke.edu/v1/AUTH_gcb/gordan_models
 
 # Gene lists and other static data for each genome

--- a/util/find_min_max.py
+++ b/util/find_min_max.py
@@ -1,0 +1,45 @@
+"""
+Prints yaml entries for adding to create_conf.yaml PREF_MIN_MAX.
+Finds the min and max for each preference file passed in.
+Usage: python find_min_max.py ../*_vs_*.bed
+You can download these files by running: python load.py download
+"""
+
+from __future__ import print_function
+import sys
+import os
+import csv
+
+
+def get_pref_min_max(path):
+    """
+    Find the min and max value for a bedfile.
+    :param path: str: path to preference bed file
+    :return:
+    """
+    pref_min = -1
+    pref_max = 1
+    with open(path) as infile:
+        csv_reader = csv.reader(infile, delimiter='\t')
+        for parts in csv_reader:
+            val = float(parts[3])
+            pref_min = min(pref_min, val)
+            pref_max = max(pref_max, val)
+    return pref_min, pref_max
+
+
+def get_genome_and_name(path):
+    filename = os.path.basename(path)
+    parts = filename.split("_")
+    return parts[0], '_'.join(parts[1:]).replace(".bed", "")
+
+
+files = sys.argv[1:]
+for path in files:
+    genome, name = get_genome_and_name(path)
+    pref_min,pref_max = get_pref_min_max(path)
+    print('- genome: {}'.format(genome))
+    print('  name: {}'.format(name))
+    print('  pref_min: {}'.format(pref_min))
+    print('  pref_max: {}'.format(pref_max))
+


### PR DESCRIPTION
Adds preference data from the separate trackhub in the `imadsconf.yaml` config file.
Updates colors based on what was done for the genome browser tracks.
Smaller model dropdown to handle more preferences.
Two trackhub urls in config and used in portal when opening UCSC genome browser.
