### PR TITLE
Docker babel core

### DIFF
--- a/portal/package.json
+++ b/portal/package.json
@@ -27,7 +27,7 @@
     "react-router": "^2.0.0",
     "react-tap-event-plugin": "^0.2.2",
     "style-loader": "^0.13.1",
-    "webpack": "^1.12.14",
+    "webpack": "^1.12.14"
   },
   "devDependencies": {
     "chai": "^3.5.0"

--- a/portal/package.json
+++ b/portal/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "babel-core": "^6.17.0",    
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-class-properties": "^6.11.5",
     "babel-polyfill": "^6.7.4",
@@ -26,7 +27,7 @@
     "react-router": "^2.0.0",
     "react-tap-event-plugin": "^0.2.2",
     "style-loader": "^0.13.1",
-    "webpack": "^1.12.14"
+    "webpack": "^1.12.14",
   },
   "devDependencies": {
     "chai": "^3.5.0"


### PR DESCRIPTION
Explicitly adds babel-core to package.json.
This caused dockerhub to skip that import and not run webpack.
I think this may be a change to babel where dockerhub is ahead of circleci/my laptop.
