### PR TITLE
use spinner for search/data sources tabs

### DIFF
--- a/portal/src/app/common/DataGrid.jsx
+++ b/portal/src/app/common/DataGrid.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {DataGridContent, TEXT_TYPE} from '../models/DataGridContent.js'
 import ErrorPanel from '../search/ErrorPanel.jsx'
 import ProgressTable from '../common/ProgressTable.jsx'
+import Loader from 'react-loader';
 
 /**
  * Row that fills the body of the DataGrid.
@@ -55,9 +56,15 @@ export default class DataGrid extends React.Component {
         let {errorMessage, searchDataLoaded, loadingStatusLabel, jobDates,
             showBlankWhenEmpty, fullScreen} = this.props;
         let numColumns = dataGridContent.getNumColumns() + 1;
-        if (!searchDataLoaded && jobDates) {
+        if (!searchDataLoaded) {
+            let content = <Loader loaded={false}></Loader>;
+            if (jobDates) {
+                content =  <ProgressTable startedDate={jobDates.started}
+                                          currentDate={jobDates.current}
+                                          status={loadingStatusLabel}/>;
+            }
             return <TallRow numColumns={numColumns}>
-                <ProgressTable startedDate={jobDates.started} currentDate={jobDates.current} status={loadingStatusLabel} />
+                {content}
             </TallRow>;
         }
         if (errorMessage) {

--- a/portal/src/app/common/DataGrid.jsx
+++ b/portal/src/app/common/DataGrid.jsx
@@ -57,7 +57,12 @@ export default class DataGrid extends React.Component {
             showBlankWhenEmpty, fullScreen} = this.props;
         let numColumns = dataGridContent.getNumColumns() + 1;
         if (!searchDataLoaded) {
-            let content = <Loader loaded={false}></Loader>;
+            let content = <div className="centerChildrenHorizontally">
+                            <span className="smallMargin">Loading...</span>
+                        </div>;
+            if (fullScreen) {
+                content = <Loader loaded={false}></Loader>;
+            }
             if (jobDates) {
                 content =  <ProgressTable startedDate={jobDates.started}
                                           currentDate={jobDates.current}

--- a/portal/src/app/common/ProgressTable.jsx
+++ b/portal/src/app/common/ProgressTable.jsx
@@ -32,7 +32,7 @@ export default class ProgressTable extends React.Component {
         let current = moment(new Date(currentDate));
         let elapsed = this.getEllapsed(started, current);
         if (!startedDate) {
-            return <div></div>;
+            return <div>Loading</div>;
         }
         return <table className="ProgressTable_table">
             <tbody>

--- a/portal/src/app/datasources/DataSource.jsx
+++ b/portal/src/app/datasources/DataSource.jsx
@@ -13,7 +13,7 @@ export default class DataSource extends React.Component {
     };
 
     render() {
-        let {title, content, hasGroups} = this.props;
+        let {title, content, hasGroups, loading} = this.props;
         let gridColumnInfo = [
             {fieldName: 'description', title: 'Description', type: 'text'},
             {fieldName: 'downloaded', title: 'Downloaded', type: 'text'},
@@ -27,7 +27,7 @@ export default class DataSource extends React.Component {
                 columnInfo={gridColumnInfo}
                 rows={content}
                 hasGroups={hasGroups}
-                searchDataLoaded={true}
+                searchDataLoaded={!loading}
             />
         </div>
     }

--- a/portal/src/app/datasources/DataSource.jsx
+++ b/portal/src/app/datasources/DataSource.jsx
@@ -27,6 +27,7 @@ export default class DataSource extends React.Component {
                 columnInfo={gridColumnInfo}
                 rows={content}
                 hasGroups={hasGroups}
+                searchDataLoaded={true}
             />
         </div>
     }

--- a/portal/src/app/datasources/DataSourcesPage.jsx
+++ b/portal/src/app/datasources/DataSourcesPage.jsx
@@ -12,6 +12,7 @@ class DataSourcesPage extends React.Component {
             predictions: [],
             genelists: [],
             models: [],
+            loading: true
         };
         this.dataSourceData = new DataSourceData();
     }
@@ -24,24 +25,31 @@ class DataSourcesPage extends React.Component {
         this.setState({
             predictions: predictions,
             genelists: genelists,
-            models: models
+            models: models,
+            loading: false
         });
     };
 
     onError = (message) => {
         alert(message);
+        this.setState({
+            predictions: [],
+            genelists: [],
+            models: [],
+            loading: false
+        });
     };
 
     render() {
-        let {predictions, genelists, models} = this.state;
+        let {predictions, genelists, models, loading} = this.state;
         return <div>
             <NavBar selected={DATA_SOURCES_NAV.path}/>
             <PageContent>
-                <DataSource title="Predictions" content={predictions}/>
+                <DataSource title="Predictions" content={predictions} loading={loading}/>
                 <br />
-                <DataSource title="Gene Lists" content={genelists}/>
+                <DataSource title="Gene Lists" content={genelists} loading={loading}/>
                 <br />
-                <DataSource title="Models" content={models} hasGroups={true} />
+                <DataSource title="Models" content={models} hasGroups={true} loading={loading}/>
             </PageContent>
         </div>;
     }


### PR DESCRIPTION
The progress table was only meant for make predictions(since it takes a while).
This adds back the spinner for the other two tabs.
