### PR TITLE
Data Source Tab changes

### DIFF
--- a/portal/src/app/common/DataGrid.jsx
+++ b/portal/src/app/common/DataGrid.jsx
@@ -36,6 +36,9 @@ export default class DataGrid extends React.Component {
         let headers = [];
         let key = 1;
         let {headerClassNamePrefix} = this.props;
+        if (headerClassNamePrefix == undefined) {
+            headerClassNamePrefix = '';
+        }
         for (let columnHeader of dataGridContent.getColumnHeaders()) {
             let headerClassName = this.makeClassName("header_" + headerClassNamePrefix + columnHeader.fieldName);
             headerClassName += " " + this.makeClassName("headerCell");

--- a/portal/src/app/datasources/DataSource.css
+++ b/portal/src/app/datasources/DataSource.css
@@ -36,10 +36,12 @@
     text-overflow: ellipsis;
     border-bottom: 1px solid grey;
     font-size: 14px;
-    height: 26px;
+    height: 18px;
     white-space: nowrap;
     line-height: 1.4;
-    padding: 10px;
+    padding-left: 10px;
+    padding-top: 2px;
+    padding-bottom: 2px;
 }
 
 .DataSource_DataGrid_group {

--- a/portal/src/app/datasources/DataSourcesPage.jsx
+++ b/portal/src/app/datasources/DataSourcesPage.jsx
@@ -9,7 +9,8 @@ class DataSourcesPage extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            predictions: [],
+            binding_predictions: [],
+            preference_predictions: [],
             genelists: [],
             models: [],
             loading: true
@@ -21,9 +22,10 @@ class DataSourcesPage extends React.Component {
         this.dataSourceData.fetchData(this.onData, this.onError);
     }
 
-    onData = (predictions, genelists, models) => {
+    onData = (binding_predictions, preference_predictions, genelists, models) => {
         this.setState({
-            predictions: predictions,
+            binding_predictions: binding_predictions,
+            preference_predictions: preference_predictions,
             genelists: genelists,
             models: models,
             loading: false
@@ -41,11 +43,13 @@ class DataSourcesPage extends React.Component {
     };
 
     render() {
-        let {predictions, genelists, models, loading} = this.state;
+        let {binding_predictions, preference_predictions, genelists, models, loading} = this.state;
         return <div>
             <NavBar selected={DATA_SOURCES_NAV.path}/>
             <PageContent>
-                <DataSource title="Predictions" content={predictions} loading={loading}/>
+                <DataSource title="Binding Predictions" content={binding_predictions} loading={loading}/>
+                <br />
+                <DataSource title="Preference Predictions" content={preference_predictions} loading={loading}/>
                 <br />
                 <DataSource title="Gene Lists" content={genelists} loading={loading}/>
                 <br />

--- a/portal/src/app/models/DataSourceData.js
+++ b/portal/src/app/models/DataSourceData.js
@@ -1,7 +1,8 @@
 import {getAndLogErrorMessage} from './AjaxErrorMessage.js'
 import {URL} from './AppSettings.js'
 
-const PREDICTION_NAME = 'prediction';
+const BINDING_PREDICTIONS_NAME = 'binding_predictions';
+const PREFERENCE_PREDITIONS_NAME = 'preference_predictions';
 const GENELIST_NAME = 'genelist';
 const MODEL_NAME = 'model';
 
@@ -15,7 +16,8 @@ class DataSourceData {
             success: function (data) {
                 let results = data.results;
                 onData(
-                    this.formatData(PREDICTION_NAME, results),
+                    this.formatData(BINDING_PREDICTIONS_NAME, results),
+                    this.formatData(PREFERENCE_PREDITIONS_NAME, results),
                     this.formatData(GENELIST_NAME, results),
                     this.formatData(MODEL_NAME, results)
                 );

--- a/pred/config.py
+++ b/pred/config.py
@@ -22,6 +22,19 @@ class DataType(object):
     PREDICTION = 'PREDICTION'
     PREFERENCE = 'PREFERENCE'
 
+    @staticmethod
+    def get_data_source_type(data_type):
+        """
+        Based on the data type determine the data source type for the data_source table.
+        :param data_type: str: either PREDICTION or PREFERENCE.
+        :return: str: type of data source for use in data_source.data_source_type database field.
+        """
+        if data_type == DataType.PREDICTION:
+            return 'binding_predictions'
+        if data_type == DataType.PREFERENCE:
+            return 'preference_predictions'
+        return 'unknown'
+
 
 def parse_config(filename):
     config = None

--- a/pred/load/loaddatabase.py
+++ b/pred/load/loaddatabase.py
@@ -9,6 +9,7 @@ import sys
 import datetime
 from multiprocessing import Pool
 from jinja2 import FileSystemLoader, Environment
+from pred.config import DataType
 from pred.load.download import GenomeDownloader, GeneListDownloader, PredictionDownloader, ModelFiles, GENE_LIST_HOST
 from pred.load.postgres import PostgresConnection, CopyCommand
 from psycopg2 import OperationalError
@@ -167,8 +168,10 @@ class DatabaseLoader(object):
                 downloader = PredictionDownloader(self.config, prediction_setting, self.update_progress)
                 filename = downloader.get_local_tsv_path()
                 self.sql_builder.copy_file_into_db(self.genome_data.genomename + '.prediction', filename)
-                self.sql_builder.insert_data_source(downloader.get_url(), downloader.get_description(),
-                                                    'prediction', filename)
+                self.sql_builder.insert_data_source(downloader.get_url(),
+                                                    downloader.get_description(),
+                                                    DataType.get_data_source_type(prediction_setting.data_type),
+                                                    filename)
         self.sql_builder.end_parallel()
 
     def create_gene_and_prediction_indexes(self):

--- a/sql_templates/create_data_source.sql
+++ b/sql_templates/create_data_source.sql
@@ -1,6 +1,6 @@
 {# creates data_source tables in public schema #}
 
-CREATE TYPE data_source_type AS ENUM ('prediction', 'genelist', 'model');
+CREATE TYPE data_source_type AS ENUM ('binding_predictions', 'preference_predictions', 'genelist', 'model');
 
 create table public.data_source (
   url varchar NOT NULL,


### PR DESCRIPTION
Splits Predictions table into Binding Predictions and Preference Predictions.
Fix DataGrid bug but related to classnames.
Make rows shorter for this tab.
Change data_source_type to have new names.
Change database loading code to populate binding_predictions and preference_predictions for prediction data.
