### PR TITLE
Preference: no underscore and better E2f1_vs_E2f4 sort max guess

### DIFF
--- a/imadsconf.yaml
+++ b/imadsconf.yaml
@@ -80,7 +80,7 @@ genome_data:
     name: Elk1_vs_Ets1
     preference_max: 25.3
     preference_min: -17.24
-    sort_max_guess: 0.6
+    sort_max_guess: 16
     type: PREFERENCE
     url: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences//hg19/hg19_Elk1_0004_vs_Ets1_0005.bb
   - core_length: 4

--- a/portal/src/app/models/Model.js
+++ b/portal/src/app/models/Model.js
@@ -1,5 +1,5 @@
 export function formatModelName(modelName) {
-    return modelName.replace(/_[0-9]+/, '');
+    return modelName.replace(/_[0-9]+/, '').replace(/_/g, ' ');
 }
 
 export function makeTitleForModelName(modelName, title) {

--- a/portal/src/app/models/Model.js
+++ b/portal/src/app/models/Model.js
@@ -1,5 +1,5 @@
 export function formatModelName(modelName) {
-    return modelName.replace(/_[0-9]+/, '').replace(/_/g, ' ');
+    return modelName.replace(/_[0-9]+/g, '').replace(/_/g, ' ');
 }
 
 export function makeTitleForModelName(modelName, title) {

--- a/portal/src/app/models/Model.js
+++ b/portal/src/app/models/Model.js
@@ -1,4 +1,6 @@
 export function formatModelName(modelName) {
+    // Remove unique model numbers and underscores from the model names.
+    // eg. 'Elk1_0004_vs_Ets1_0005' -> 'Elk1 vs Ets1'
     return modelName.replace(/_[0-9]+/g, '').replace(/_/g, ' ');
 }
 

--- a/portal/src/tests/testModel.js
+++ b/portal/src/tests/testModel.js
@@ -11,6 +11,7 @@ describe('Model', function () {
 
         it('strips _ from _vs_ names', function () {
              assert.equal('Elk1 vs Ets1', formatModelName('Elk1_vs_Ets1'));
+            assert.equal('Elk1 vs Ets1', formatModelName('Elk1_0004_vs_Ets1_0005'));
         });
     });
 

--- a/portal/src/tests/testModel.js
+++ b/portal/src/tests/testModel.js
@@ -7,7 +7,10 @@ describe('Model', function () {
             assert.equal('c-Myc', formatModelName('c-Myc_0001'));
             assert.equal('Mad1', formatModelName('Mad1_0002'));
             assert.equal('Gabpa', formatModelName('Gabpa_0006'));
-            assert.equal('E2f1_vs_E2f4', formatModelName('E2f1_vs_E2f4'));
+        });
+
+        it('strips _ from _vs_ names', function () {
+             assert.equal('Elk1 vs Ets1', formatModelName('Elk1_vs_Ets1'));
         });
     });
 
@@ -15,7 +18,7 @@ describe('Model', function () {
         it('should clean model and add title', function () {
             assert.equal('c-Myc predictions for details', makeTitleForModelName('c-Myc_0001', 'details'));
             assert.equal('Gabpa predictions for WASH7P', makeTitleForModelName('Gabpa_0006', 'WASH7P'));
-            assert.equal('E2f1_vs_E2f4 preferences for WASH7P', makeTitleForModelName('E2f1_vs_E2f4', 'WASH7P'));
+            assert.equal('E2f1 vs E2f4 preferences for WASH7P', makeTitleForModelName('E2f1_vs_E2f4', 'WASH7P'));
         });
     });
 });

--- a/util/create_conf.yaml
+++ b/util/create_conf.yaml
@@ -31,6 +31,7 @@ SORT_MAX_GUESS:
   'E2f4_0009': 0.65
   'Runx1_0010': 0.7
   'Runx2_0011': 0.8
+  'Elk1_vs_Ets1': 16
 
 PREF_MIN_MAX:
 - genome: hg38


### PR DESCRIPTION
Removing the underscore from the ModelSelect dropdown for preferences.
"E2f1_vs_E2f4" -> "E2f1 vs E2f4"
Update sort_max_guess for E2f1_vs_E2f4 so we can quickly return the top 30K items when sorting by max. 
