### PR TITLE
Smaller db through compact indexes

### DIFF
--- a/pred/queries/genelistquery.py
+++ b/pred/queries/genelistquery.py
@@ -35,17 +35,17 @@ class GeneListQuery(object):
             comparison_fieldname = "common_name"
         query_parts = [
             select_prediction_values(table_name="custom_gene_list",
-                                     first_field="gene_name as common_name"),
+                                     first_field="max(gene_name) as common_name"),
             alias_join_gene_prediction(comparison_fieldname),
             and_sql(),
             join_filter,
             where(),
             id_equals(self.custom_list_id),
-            group_by_common_name_and_parts(first_field="gene_name"),
+            group_by_gene_id(),
         ]
         if not self.count:
             if self.sort_by_max:
-                query_parts.append(order_by_max_value_desc_common_name())
+                query_parts.append(order_by_max_value_desc_gene_id())
             else:
                 query_parts.append(order_by_gene_name())
         if self.limit:

--- a/pred/queries/maxpredictionquery.py
+++ b/pred/queries/maxpredictionquery.py
@@ -33,7 +33,7 @@ class MaxPredictionQuery(object):
         ]
         if self.guess and not self.count:
             with_parts.append(value_greater_than(self.guess))
-        with_parts.append(group_by_common_name_and_parts())
+        with_parts.append(group_by_gene_id())
         with_parts.append(order_by_max_value_desc())
         if self.limit:
             with_parts.append(limit_and_offset(self.limit, self.offset))
@@ -42,13 +42,13 @@ class MaxPredictionQuery(object):
 
     def main_query_parts(self):
         query_parts = [
-            select_prediction_values(),
+            select_prediction_values(first_field="max(common_name) as common_name"),
             where(),
             filter_gene_list(self.gene_list, self.model_name, self.upstream, self.downstream),
-            name_in_max_prediction_names(),
-            group_by_common_name_and_parts(),
+            gene_id_in_max_prediction_names(),
+            group_by_gene_id(),
         ]
         if not self.count:
-            query_parts.append(order_by_max_value_desc_common_name())
+            query_parts.append(order_by_max_value_desc_gene_id())
         return query_parts
 

--- a/pred/queries/predictionquery.py
+++ b/pred/queries/predictionquery.py
@@ -25,13 +25,13 @@ class PredictionQuery(object):
 
     def main_query_parts(self):
         query_parts = [
-            select_prediction_values(),
+            select_prediction_values(first_field="max(common_name) as common_name"),
             where(),
             filter_gene_list(self.gene_list, self.model_name, self.upstream, self.downstream),
-            group_by_common_name_and_parts(),
+            group_by_gene_id(),
         ]
         if not self.count:
-            query_parts.append(order_by_chrom_and_txstart())
+            query_parts.append(order_by_gene_id())
         if self.limit:
             query_parts.append(limit_and_offset(self.limit, self.offset))
         return query_parts

--- a/pred/queries/predictionqueryparts.py
+++ b/pred/queries/predictionqueryparts.py
@@ -42,9 +42,9 @@ case WHEN max(value) > abs(min(value)) THEN
 ELSE
   round(min(value), 4)
 end as max_value,
-chrom,
-strand,
-gene_begin,
+max(chrom) as chrom,
+max(strand) as strand,
+max(gene_begin) as gene_begin,
 json_agg(json_build_object('value', round(value, 4), 'start', start_range, 'end', end_range)) as pred
 from {}""".format(first_field, table_name))
 
@@ -58,8 +58,8 @@ def id_equals(id_value):
     return QueryPart("""id = %s""", [id_value])
 
 
-def name_in_max_prediction_names():
-    return _query_part("and common_name in (select common_name from max_prediction_names)")
+def gene_id_in_max_prediction_names():
+    return _query_part("and gene_id in (select gene_id from max_prediction_names)")
 
 
 def filter_gene_list(gene_list, model_name, upstream, downstream):
@@ -103,7 +103,7 @@ where id = %s and not exists
 
 def with_max_prediction_names():
     return _query_part("""with max_prediction_names as (
- select common_name from gene_prediction""")
+ select gene_id from gene_prediction""")
 
 
 def end_with():
@@ -126,6 +126,13 @@ def group_by_common_name_and_parts(first_field="common_name"):
     return _query_part("group by {}, chrom, strand, gene_begin".format(first_field))
 
 
+def group_by_gene_id():
+    return _query_part("group by gene_id")
+
+
+def order_by_gene_id():
+    return _query_part("order by gene_id")
+
 def order_by_chrom_and_txstart():
     return _query_part("order by chrom, gene_begin")
 
@@ -135,16 +142,11 @@ def order_by_name():
 
 
 def order_by_gene_name():
-    return _query_part("order by gene_name")
+    return _query_part("order by max(gene_name)")
 
 
 def order_by_common_name_and_name():
     return _query_part("order by common_name, name")
-
-
-def order_by_chrom_txstart():
-    return _query_part("order by chrom, txstart")
-
 
 def order_by_seq():
     return _query_part("order by seq")
@@ -154,8 +156,8 @@ def order_by_max_value_desc():
     return _query_part("order by max(abs(value)) desc")
 
 
-def order_by_max_value_desc_common_name():
-    return _query_part("order by max(abs(value)) desc, common_name")
+def order_by_max_value_desc_gene_id():
+    return _query_part("order by max(abs(value)) desc, gene_id")
 
 
 def limit_and_offset(limit, offset):

--- a/sql_templates/create_base_tables.sql
+++ b/sql_templates/create_base_tables.sql
@@ -23,11 +23,11 @@ CREATE TABLE {{ schema_prefix }}.gene (
   txstart int NOT NULL,
   txend int NOT NULL,
   gene_begin int NOT NULL,
-  range int4range
+  range int4range,
+  gene_id integer
 );
 GRANT ALL PRIVILEGES ON {{ schema_prefix }}.gene TO pred_user;
 CREATE index gene_list_idx on {{ schema_prefix }}.gene(gene_list);
-
 
 CREATE TABLE {{ schema_prefix }}.gene_prediction (
   gene_list varchar NOT NULL,
@@ -35,8 +35,7 @@ CREATE TABLE {{ schema_prefix }}.gene_prediction (
   common_name varchar,
   chrom varchar NOT NULL,
   strand char(1) NOT NULL,
-  txstart int NOT NULL,
-  txend int NOT NULL,
+  gene_id int NOT NULL,
   gene_begin int NOT NULL,
   model_name {{ schema_prefix }}.model_type NOT NULL,
   value numeric NOT NULL,

--- a/sql_templates/create_gene_index.sql
+++ b/sql_templates/create_gene_index.sql
@@ -1,3 +1,41 @@
 create index if not exists gene_range_idx on {{ schema_prefix }}.gene using gist(range);
 create index if not exists gene_list_chrom on {{ schema_prefix }}.gene(gene_list, chrom);
+
+-- generate gene_id's to allow easy sorting/group by chrom, gene_begin, common_name, strand
+-- combines chrom, gene_begin, common_name, strand -> gene_id
+-- create table
+create table unique_gene (
+gene_id serial,
+common_name varchar,
+chrom varchar,
+strand varchar,
+gene_begin integer);
+
+-- populate table filling in serial (gene_id)
+insert into  unique_gene(common_name, chrom, strand, gene_begin)
+select common_name, chrom, strand, gene_begin
+from {{ schema_prefix }}.gene group by common_name, chrom, strand, gene_begin
+order by chrom, gene_begin, common_name, strand;
+
+-- create index to speed up next step
+create index ugidx on unique_gene (common_name, chrom, strand, gene_begin);
+
+-- put gene_id values back into gene table.
+update {{ schema_prefix }}.gene set gene_id = (
+select gene_id from unique_gene
+where
+gene.common_name = unique_gene.common_name
+and
+gene.chrom = unique_gene.chrom
+and
+gene.strand = unique_gene.strand
+and
+gene.gene_begin = gene_begin);
+
+-- drop table we no longer need
+drop table unique_gene;
+
+-- create an index for lookup purposes
+CREATE index gene_list_id_idx on {{ schema_prefix }}.gene(gene_id);
+
 ANALYZE {{ schema_prefix }}.gene;

--- a/sql_templates/create_gene_prediction_indexes.sql
+++ b/sql_templates/create_gene_prediction_indexes.sql
@@ -4,9 +4,6 @@ create index if not exists gene_prediction_grouped_idx
 create index if not exists gene_prediction_value_idx
  on {{ schema_prefix }}.gene_prediction(gene_list, model_name, abs(value) DESC);
 
-create index if not exists gene_prediction_max_sort_idx
- on {{ schema_prefix }}.gene_prediction(gene_list, model_name, common_name);
-
 -- for custom gene list speedup
 create index gene_prediction_common_name_search_idx
  on {{ schema_prefix }}.gene_prediction(upper(common_name));

--- a/sql_templates/create_gene_prediction_indexes.sql
+++ b/sql_templates/create_gene_prediction_indexes.sql
@@ -1,10 +1,14 @@
 create index if not exists gene_prediction_grouped_idx
- on {{ schema_prefix }}.gene_prediction(gene_list, model_name, chrom, gene_begin, common_name, strand);
+ on {{ schema_prefix }}.gene_prediction(gene_list, gene_id);
 
 create index if not exists gene_prediction_value_idx
  on {{ schema_prefix }}.gene_prediction(gene_list, model_name, abs(value) DESC);
 
 create index if not exists gene_prediction_max_sort_idx
  on {{ schema_prefix }}.gene_prediction(gene_list, model_name, common_name);
+
+-- for custom gene list speedup
+create index gene_prediction_common_name_search_idx
+ on {{ schema_prefix }}.gene_prediction(upper(common_name));
 
 analyze {{ schema_prefix }}.gene_prediction;

--- a/sql_templates/insert_gene_prediction.sql
+++ b/sql_templates/insert_gene_prediction.sql
@@ -1,5 +1,5 @@
 insert into  {{ schema_prefix }}.gene_prediction
-select gene.gene_list, name, common_name, gene.chrom, strand, txstart, txend, gene_begin, prediction.model_name, value,
+select gene.gene_list, name, common_name, gene.chrom, strand, gene_id, gene_begin, prediction.model_name, value,
        start_range, end_range
  from {{ schema_prefix }}.gene
     inner join {{ schema_prefix }}.prediction

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -274,6 +274,9 @@ class TestWithPostgres(unittest.TestCase):
         self.assertEqual(len(predictions), 1)
 
     def test_custom_gene_list_id_results(self):
+        """
+        These two splice variants belong to the same gene so they should list together in a single prediction.
+        """
         db = create_db_connection(TestWithPostgres.config.dbconfig)
         custom_list_key = save_custom_file(db, 'john', GENE_LIST_TYPE, "uc001aaa.3\nuc010nxr.1")
         params = {
@@ -287,16 +290,12 @@ class TestWithPostgres(unittest.TestCase):
             SearchArgs.PER_PAGE: "10",
         }
         predictions, search_args, search_warning = get_predictions_with_guess(db, TestWithPostgres.config, "hg19", params)
-        self.assertEqual(len(predictions), 2)
+        self.assertEqual(len(predictions), 1)
         first_pred_name = predictions[0]['name']
         first_pred_name_parts = first_pred_name.split("; ")
-        self.assertEqual(len(first_pred_name_parts), 1)
+        self.assertEqual(len(first_pred_name_parts), 2)
         self.assertIn("uc001aaa.3", first_pred_name_parts)
-
-        second_pred_name = predictions[1]['name']
-        second_pred_name_parts = second_pred_name.split("; ")
-        self.assertEqual(len(second_pred_name_parts), 1)
-        self.assertIn("uc010nxr.1", second_pred_name_parts)
+        self.assertIn("uc010nxr.1", first_pred_name_parts)
 
     def test_custom_gene_list_with_lc_results(self):
         db = create_db_connection(TestWithPostgres.config.dbconfig)

--- a/tests/test_predictionquery.py
+++ b/tests/test_predictionquery.py
@@ -3,16 +3,16 @@ from pred.queries.predictionquery import PredictionQuery
 
 QUERY_BASE = """SET search_path TO %s,public;
 select
-common_name,
+max(common_name) as common_name,
 string_agg(name, '; ') as name,
 case WHEN max(value) > abs(min(value)) THEN
   round(max(value), 4)
 ELSE
   round(min(value), 4)
 end as max_value,
-chrom,
-strand,
-gene_begin,
+max(chrom) as chrom,
+max(strand) as strand,
+max(gene_begin) as gene_begin,
 json_agg(json_build_object('value', round(value, 4), 'start', start_range, 'end', end_range)) as pred
 from gene_prediction
 where
@@ -25,8 +25,8 @@ case strand when '+' then
 else
   (gene_begin + %s) >= start_range and end_range >= (gene_begin - %s)
 end
-group by common_name, chrom, strand, gene_begin
-order by chrom, gene_begin{}"""
+group by gene_id
+order by gene_id{}"""
 
 GENE_LIST_FILTER_WITH_LIMIT = QUERY_BASE.format("\nlimit %s offset %s")
 GENE_LIST_FILTER = QUERY_BASE.format("")
@@ -34,16 +34,16 @@ GENE_LIST_FILTER = QUERY_BASE.format("")
 COUNT_QUERY = """SET search_path TO %s,public;
 select count(*) from (
 select
-common_name,
+max(common_name) as common_name,
 string_agg(name, '; ') as name,
 case WHEN max(value) > abs(min(value)) THEN
   round(max(value), 4)
 ELSE
   round(min(value), 4)
 end as max_value,
-chrom,
-strand,
-gene_begin,
+max(chrom) as chrom,
+max(strand) as strand,
+max(gene_begin) as gene_begin,
 json_agg(json_build_object('value', round(value, 4), 'start', start_range, 'end', end_range)) as pred
 from gene_prediction
 where
@@ -56,7 +56,7 @@ case strand when '+' then
 else
   (gene_begin + %s) >= start_range and end_range >= (gene_begin - %s)
 end
-group by common_name, chrom, strand, gene_begin
+group by gene_id
 ) as foo"""
 
 class TestPredictionQuery(TestCase):
@@ -73,7 +73,7 @@ class TestPredictionQuery(TestCase):
             offset="200",
         )
         sql, params = query.get_query_and_params()
-        self.assertEqual(expected_sql, sql)
+        self.assertMultiLineEqual(expected_sql, sql)
         self.assertEqual(expected_params, params)
 
     def test_filter(self):
@@ -88,7 +88,7 @@ class TestPredictionQuery(TestCase):
         )
         sql, params = query.get_query_and_params()
         self.maxDiff = None
-        self.assertEqual(expected_sql, sql)
+        self.assertMultiLineEqual(expected_sql, sql)
         self.assertEqual(expected_params, params)
 
     def test_count(self):
@@ -104,7 +104,7 @@ class TestPredictionQuery(TestCase):
         )
         sql, params = query.get_query_and_params()
         self.maxDiff = None
-        self.assertEqual(expected_sql, sql)
+        self.assertMultiLineEqual(expected_sql, sql)
         self.assertEqual(expected_params, params)
 
 


### PR DESCRIPTION
Adds new gene_id field to gene table.
gene_id is built from chrom, gene_begin, common_name, strand and ordered that way.
Within the gene lists we download there is no unique identifier for what we consider to be a gene.
There is a gene symbol and id but we consider a gene to be a gene_symbol + TSS.

Loading code will now populate this new field.
Queries will make use of this field.

Also fixes an issue with sort by max + preference data and paging related to the same gene symbol on multiple chroms.
