### PR TITLE
Changes ServerName and redirect in apache conf to imads.gcb.duke.edu

### DIFF
--- a/production/imads.conf
+++ b/production/imads.conf
@@ -1,8 +1,8 @@
 # Always redirect to SSL
-ServerName tfpredictions-dev.gcb.duke.edu
+ServerName imads.gcb.duke.edu
 <VirtualHost *:80>
-   ServerName tfpredictions-dev.duke.edu
-   Redirect permanent / https://tfpredictions-dev.gcb.duke.edu
+   ServerName imads.gcb.duke.edu
+   Redirect permanent / https://imads.gcb.duke.edu
 </VirtualHost>
 
 # Static Files
@@ -56,7 +56,7 @@ WSGIPassAuthorization On
 
 # SSL
 <VirtualHost *:443>
-  ServerName tfpredictions-dev.gcb.duke.edu
+  ServerName imads.gcb.duke.edu
   SSLEngine on
   SSLCertificateFile /etc/external/ssl/cacert.pem
   SSLCertificateKeyFile /etc/external/ssl/privkey.pem


### PR DESCRIPTION
CNAME is already registered in aka, but we will need an SSL certificate.