### PR TITLE
warn user about duplicate sequence names

### DIFF
--- a/portal/src/app/common/SingleFileUpload.css
+++ b/portal/src/app/common/SingleFileUpload.css
@@ -1,4 +1,5 @@
-.SingleFileUpload_input {
+input[type=file].SingleFileUpload_input {
+    display: inline-block;
     margin-top: 10px;
     margin-bottom: 10px;
 }

--- a/portal/src/app/prediction/UploadSequenceDialog.css
+++ b/portal/src/app/prediction/UploadSequenceDialog.css
@@ -1,0 +1,6 @@
+.UploadSequenceDialog_uploadErrorMessage {
+    color: red;
+    float: right;
+    margin: 10px;
+    font-size: 14pt;
+}

--- a/portal/src/app/prediction/UploadSequenceDialog.jsx
+++ b/portal/src/app/prediction/UploadSequenceDialog.jsx
@@ -8,6 +8,7 @@ import LoadSampleLink from '../common/LoadSampleLink.jsx'
 import FileUpload from '../models/FileUpload.js';
 import {CustomSequence, CustomSequenceList} from '../models/CustomSequence.js';
 import {SEQUENCE_SAMPLE} from '../models/SampleData.js'
+require('./UploadSequenceDialog.css');
 
 const TITLE = "Custom DNA Sequence";
 const INSTRUCTIONS = "Enter Sequence/FASTA data or choose a file in that format. (Max file size 20MB)";
@@ -20,7 +21,8 @@ const DEFAULT_STATE = {
     fileValue: undefined,
     textValue: '',
     sequenceName: '',
-    titleErrorMessage: ''
+    titleErrorMessage: '',
+    uploadErrorMessage: ''
 };
 
 class UploadSequenceDialog extends React.Component {
@@ -30,13 +32,13 @@ class UploadSequenceDialog extends React.Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        if (nextProps.sequenceData.id) {
-            let customSequence = new CustomSequence();
-            customSequence.fetch(nextProps.sequenceData.id, this.onSequenceInfo, this.onSequenceInfoError);
-        }
         // reset state each time this dialog is shown
         if (nextProps.isOpen && !this.props.isOpen) {
             this.setState(DEFAULT_STATE);
+            if (nextProps.sequenceData.id) {
+                let customSequence = new CustomSequence();
+                customSequence.fetch(nextProps.sequenceData.id, this.onSequenceInfo, this.onSequenceInfoError);
+            }
         }
     }
 
@@ -53,6 +55,7 @@ class UploadSequenceDialog extends React.Component {
             canUpload: true,
             textValue: value,
             file: undefined,
+            uploadErrorMessage: '',
             fileValue: undefined
         })
     };
@@ -62,6 +65,7 @@ class UploadSequenceDialog extends React.Component {
             canUpload: true,
             textValue: '',
             file: file,
+            uploadErrorMessage: '',
             fileValue: fileValue
         })
     };
@@ -98,7 +102,9 @@ class UploadSequenceDialog extends React.Component {
     };
 
     onUploadedSequenceFailed = (errorMessage) => {
-        this.closeDialog(undefined, errorMessage, '');
+        this.setState({
+            uploadErrorMessage: errorMessage
+        });
     };
 
     closeDialog = (seqId, errorMessage, title) => {
@@ -173,11 +179,15 @@ class UploadSequenceDialog extends React.Component {
                            onChange={this.onChangeTextValue}
                            disabled={this.state.loading}
             />
-            <SingleFileUpload fileValue={this.state.fileValue}
-                              loading={this.state.loading}
-                              onChangeFile={this.onChangeFile}
-                              disabled={this.state.loading}
-            />
+            <div>
+                <SingleFileUpload fileValue={this.state.fileValue}
+                                  loading={this.state.loading}
+                                  onChangeFile={this.onChangeFile}
+                                  disabled={this.state.loading}
+                />
+                <span className="UploadSequenceDialog_uploadErrorMessage">{this.state.uploadErrorMessage}</span>
+            </div>
+
             <LoadingButton label="Upload"
                            loading={this.state.loading}
                            disabled={!canUpload}

--- a/pred/webserver/errors.py
+++ b/pred/webserver/errors.py
@@ -2,6 +2,7 @@
 class ErrorType(object):
     GENERIC_ERROR = 'generic'
     SEQUENCE_NOT_FOUND = 'sequence_not_found'
+    INVALID_SEQUENCE_DATA = 'invalid_sequence_data'
 
 
 class BaseWebException(Exception):

--- a/pred/webserver/sequencelist.py
+++ b/pred/webserver/sequencelist.py
@@ -3,6 +3,7 @@ Stores custom FASTA sequences under a uuid in the database.
 Part of the tables used for custom jobs.
 """
 import uuid
+from pred.webserver.errors import ClientException, ErrorType
 from pred.queries.dbutil import update_database, read_database
 from Bio import SeqIO
 from StringIO import StringIO
@@ -144,4 +145,16 @@ class SequenceListItems(object):
                 'sequence': str(seq.seq)
             })
             cnt += 1
+        SequenceListItems.verify_unique_names(results)
         return results
+
+    @staticmethod
+    def verify_unique_names(items):
+        """
+        Make sure that we don't have any duplicate names in the list.
+        Raises UserFacingException if the names are duplicated.
+        :param items: [{}]: list of dictionaries with name property to check
+        """
+        unique_names = set([item['name'] for item in items])
+        if len(unique_names) != len(items):
+            raise ClientException("Error: Duplicate sequence names found.", ErrorType.INVALID_SEQUENCE_DATA)


### PR DESCRIPTION
Users who upload sequences with duplicate names get an error back from the prediction/preference generator.
Checking for this before creating the sequence and displaying an error back to the user.
Fixes #102 