### PR TITLE
Global ServerName was messing up https redirect

### DIFF
--- a/production/imads.conf
+++ b/production/imads.conf
@@ -1,5 +1,5 @@
 # Always redirect to SSL
-ServerName imads.genome.duke.edu
+ServerName localhost
 <VirtualHost *:80>
    ServerName imads.genome.duke.edu
    Redirect permanent / https://imads.genome.duke.edu


### PR DESCRIPTION
We already had code to redirect to https:
```
<VirtualHost *:80>
   ServerName imads.genome.duke.edu
   Redirect permanent / https://imads.genome.duke.edu
</VirtualHost>
```
Changing the root ServerName to localhost fixes this.

I think this might be necessary because apache is running inside docker with a different ip address.
imads.genome.duke.edu resolves to 152.3.102.107 which matches host machine.
inside docker it thinks it's ipaddress is 172.18.0.3.

