### PR TITLE
Remove un-necessary chromosome filter

### DIFF
--- a/portal/src/app/common/PredictionDetailTable.jsx
+++ b/portal/src/app/common/PredictionDetailTable.jsx
@@ -33,10 +33,8 @@ export default class PredictionDetailTable extends React.Component {
         let ctr = 0;
         for (let detail of detailList) {
             let {rowClassName, chrom, start, end, value, seq} = detail;
-            if (chrom) { //ignore empty rows
-                details.push(this.makeRow(ctr, rowClassName, chrom, start, end, value, seq));
-                ctr += 1;
-            }
+            details.push(this.makeRow(ctr, rowClassName, chrom, start, end, value, seq));
+            ctr += 1;
         }
         return details;
     }


### PR DESCRIPTION
To handle empty rows for left outer join changes I added a filter that accidentally removed rows without chromosomes. Custom sequences do not have chromosomes returned. This filter is no longer needed since empty rows will no longer be sent to PredictionDetailTable.