### PR TITLE
Allow negative values in download CSV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
 FROM python:2.7.11
 EXPOSE 80
 ENV MYDIR /tfdnapredictions
-RUN apt-get update
-RUN apt-get install nodejs -y
-RUN apt-get install npm -y
-RUN ln -s /usr/bin/nodejs /usr/bin/node
+RUN curl -sL https://deb.nodesource.com/setup_7.x | bash -
+RUN apt-get install -y nodejs
 
 # Install bigBedToBed
 ADD http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/bigBedToBed /usr/local/bin/bigBedToBed
 RUN ["chmod", "777", "/usr/local/bin/bigBedToBed"]
 
 # Install global dependencies
-RUN npm install -g npm
 RUN npm install webpack -g
 RUN ["pip", "install", "gunicorn"]
 

--- a/pred/webserver/predictionsearch.py
+++ b/pred/webserver/predictionsearch.py
@@ -52,7 +52,7 @@ def get_all_values(prediction, size):
         value = data['value']
         idx = start - offset
         if 0 <= idx <= size:
-            if value > values[idx]:
+            if abs(value) > abs(values[idx]):
                 values[idx] = value
     result = [str(val) for val in values]
     if 'strand' in prediction:

--- a/tests/test_predictionsearch.py
+++ b/tests/test_predictionsearch.py
@@ -1,0 +1,82 @@
+from unittest import TestCase
+from pred.webserver.predictionsearch import get_all_values
+
+
+class TestPredictionSearch(TestCase):
+    def test_get_all_values_without_size(self):
+        prediction = {
+            'start': 0,
+            'end': 5,
+            'values': [
+                {
+                    'start': 1,
+                    'value': 1.2
+                }
+            ]
+        }
+        expected = ['0', '1.2', '0', '0', '0']
+        self.assertEqual(expected, get_all_values(prediction, None))
+
+    def test_get_all_values_with_size(self):
+        prediction = {
+            'start': 0,
+            'end': 5,
+            'values': [
+                {
+                    'start': 1,
+                    'value': 1.2
+                },
+                {
+                    'start': 2,
+                    'value': 5.2
+                },
+            ]
+        }
+        expected = ['0', '1.2', '5.2', '0', '0', '0', '0', '0']
+        self.assertEqual(expected, get_all_values(prediction, 8))
+
+    def test_negative_values_guess_size(self):
+        prediction = {
+            'start': 0,
+            'end': 5,
+            'values': [
+                {
+                    'start': 1,
+                    'value': -1.2
+                }
+            ]
+        }
+        expected = ['0', '-1.2', '0', '0', '0']
+        self.assertEqual(expected, get_all_values(prediction, None))
+
+    def test_negative_values_guess_with_size(self):
+        prediction = {
+            'start': 0,
+            'end': 5,
+            'values': [
+                {
+                    'start': 1,
+                    'value': -1.2
+                }
+            ]
+        }
+        expected = ['0', '-1.2', '0', '0', '0', '0']
+        self.assertEqual(expected, get_all_values(prediction, 6))
+
+    def test_overlap_most_extreem_value_wins(self):
+        prediction = {
+            'start': 0,
+            'end': 5,
+            'values': [
+                {
+                    'start': 1,
+                    'value': 1.2
+                },
+                {
+                    'start': 1,
+                    'value': -1.3
+                },
+            ]
+        }
+        expected = ['0', '-1.3', '0', '0', '0']
+        self.assertEqual(expected, get_all_values(prediction, None))


### PR DESCRIPTION
Code to build up CSV columns from prediction data was written before we had negative predictions(preference predictions) so it assumed 0 as a minimum.
The problem was due to code that handles overlapping predictions where we take the highest value.
Changes here make it so we take the highest abs(value).

Additionally webpack broke when building the docker image.
It looks like webpack was trying to use an es6 feature (arrow functions) which wasn't supported in debian's nodejs. Not sure why this just started failing.
I changed the dockerfile to upgrade nodejs per the [official instructions](https://nodejs.org/en/download/package-manager/#enterprise-linux-and-fedora)

