### PR TITLE
Fix backwards upstream and downstream values in query

### DIFF
--- a/pred/queries/predictionqueryparts.py
+++ b/pred/queries/predictionqueryparts.py
@@ -68,18 +68,13 @@ def gene_id_in_max_prediction_names():
 def filter_gene_list(gene_list, model_name, upstream, downstream):
     """
     Overlapping range filter.
-    SQL Explanation:
-    The end of the prediction must come after the start of the gene
-    and the end of the gene must come after the start of the prediction.
-    http://nedbatchelder.com/blog/201310/range_overlap_in_two_compares.html
-    end1 >= start2 and end2 <= start1
     """
     beginning_sql = ""
     params = []
     if gene_list and gene_list.upper() != 'ALL':
         beginning_sql = "gene_list = %s\nand\n"
         params.append(gene_list)
-    params.extend([model_name, downstream, upstream, upstream, downstream])
+    params.extend([model_name, upstream, downstream, downstream, upstream])
     return QueryPart(beginning_sql + """model_name = %s
 and
 case strand when '+' then

--- a/tests/test_genelistquery.py
+++ b/tests/test_genelistquery.py
@@ -68,7 +68,7 @@ group by gene_id
 class TestGeneListQuery(TestCase):
     def test_gene_list_filter_with_limit(self):
         expected_sql = GENE_LIST_FILTER_WITH_LIMIT
-        expected_params = ["hg38", "knowngene", "E2F4", "250", "150", "150", "250", 55, "100", "200"]
+        expected_params = ["hg38", "knowngene", "E2F4", "150", "250", "250", "150", 55, "100", "200"]
         query = GeneListQuery(
             schema="hg38",
             custom_list_id=55,
@@ -87,7 +87,7 @@ class TestGeneListQuery(TestCase):
 
     def test_gene_list_filter(self):
         expected_sql = GENE_LIST_FILTER
-        expected_params = ["hg38", "E2F4", "250", "150", "150", "250", 45]
+        expected_params = ["hg38", "E2F4", "150", "250", "250", "150", 45]
         query = GeneListQuery(
             schema="hg38",
             custom_list_id=45,
@@ -104,7 +104,7 @@ class TestGeneListQuery(TestCase):
 
     def test_gene_list_count(self):
         expected_sql = COUNT_QUERY
-        expected_params = ["hg38", "E2F4", "250", "150", "150", "250", 77]
+        expected_params = ["hg38", "E2F4", "150", "250", "250", "150", 77]
         query = GeneListQuery(
             schema="hg38",
             custom_list_id=77,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,8 +1,5 @@
-from unittest import TestCase
 import unittest
 import os
-import subprocess
-import time
 from StringIO import StringIO
 from pred.config import parse_config_from_dict, DataType
 from load import run_sql_command
@@ -14,9 +11,8 @@ from webserver import create_db_connection
 from pred.webserver.customlist import save_custom_file, GENE_LIST_TYPE, RANGE_TYPE, MAX_RANGE_ERROR_STR
 from pred.webserver.sequencelist import SequenceList
 from pred.webserver.customjob import CustomJob, JobStatus
-from pred.webserver.customresult import CustomResultData, SEQUENCE_NOT_FOUND
+from pred.webserver.customresult import CustomResultData
 from pred.queries.dbutil import update_database
-from pred.webserver.dbdatasource import DataSources
 import json
 
 
@@ -125,13 +121,13 @@ def make_pred_line(chrom, start, stop, value, name):
 
 
 def make_prediction_data():
-    #gene starts at 11873
+    #gene starts at 11873 (TSS)
     lines = [
         make_pred_line("chr1", 11874, 11894, 0.4, "E2F1_0001(JS)"),
-        make_pred_line("chr1", 11753, 11773, 0.3, "E2F1_0001(JS)"), # far left edge of DDX11L1(11873) upstream 100
-        make_pred_line("chr1", 11752, 11772, 0.2, "E2F1_0001(JS)"), # just past far left edge of DDX11L1(11873) upstream 100
-        make_pred_line("chr1", 11923, 11943, 0.1, "E2F1_0001(JS)"),  # far right edge of DDX11L1(11873) downstream 50
-        make_pred_line("chr1", 11924, 11944, 0.5, "E2F1_0001(JS)"),  # far right edge of DDX11L1(11873) downstream 50
+        make_pred_line("chr1", 11773, 11793, 0.3, "E2F1_0001(JS)"), # far left edge of DDX11L1(11873) upstream 100
+        make_pred_line("chr1", 11772, 11792, 0.2, "E2F1_0001(JS)"), # just past far left edge of DDX11L1(11873) upstream 100
+        make_pred_line("chr1", 11903, 11923, 0.1, "E2F1_0001(JS)"), # far right edge of DDX11L1(11873) downstream 50
+        make_pred_line("chr1", 11904, 11924, 0.5, "E2F1_0001(JS)"), # far right edge of DDX11L1(11873) downstream 50
     ]
     return "\n".join(lines)
 

--- a/tests/test_maxpredictionquery.py
+++ b/tests/test_maxpredictionquery.py
@@ -97,8 +97,8 @@ group by gene_id
 class TestMaxPredictionQuery(TestCase):
     def test_max_with_guess_and_limit(self):
         expected_sql = MAX_QUERY_WITH_GUESS_WITH_LIMIT
-        expected_params = ["hg38", "refgene", "E2F4", "250", "150", "150", "250", "0.4", "100", "200",
-                           "refgene", "E2F4", "250", "150", "150", "250"]
+        expected_params = ["hg38", "refgene", "E2F4", "150", "250", "250", "150", "0.4", "100", "200",
+                           "refgene", "E2F4", "150", "250", "250", "150"]
         query = MaxPredictionQuery(
             schema="hg38",
             gene_list="refgene",
@@ -116,8 +116,8 @@ class TestMaxPredictionQuery(TestCase):
 
     def test_max_with_guess(self):
         expected_sql = MAX_QUERY_WITH_GUESS
-        expected_params = ["hg38", "refgene", "E2F4", "250", "150", "150", "250", "0.4",
-                           "refgene", "E2F4", "250", "150", "150", "250"]
+        expected_params = ["hg38", "refgene", "E2F4", "150", "250", "250", "150", "0.4",
+                           "refgene", "E2F4", "150", "250", "250", "150"]
         query = MaxPredictionQuery(
             schema="hg38",
             gene_list="refgene",
@@ -133,8 +133,8 @@ class TestMaxPredictionQuery(TestCase):
 
     def test_max_with_no_guess_and_limit(self):
         expected_sql = MAX_QUERY_NO_GUESS_WITH_LIMIT
-        expected_params = ["hg38", "refgene", "E2F4", "250", "150", "150", "250", "100", "200",
-                           "refgene", "E2F4", "250", "150", "150", "250"]
+        expected_params = ["hg38", "refgene", "E2F4", "150", "250", "250", "150", "100", "200",
+                           "refgene", "E2F4", "150", "250", "250", "150"]
         query = MaxPredictionQuery(
             schema="hg38",
             gene_list="refgene",
@@ -150,8 +150,8 @@ class TestMaxPredictionQuery(TestCase):
 
     def test_max_with_no_guess(self):
         expected_sql = MAX_QUERY_NO_GUESS
-        expected_params = ["hg38", "refgene", "E2F4", "250", "150", "150", "250",
-                           "refgene", "E2F4", "250", "150", "150", "250"]
+        expected_params = ["hg38", "refgene", "E2F4", "150", "250", "250", "150",
+                           "refgene", "E2F4", "150", "250", "250", "150"]
         query = MaxPredictionQuery(
             schema="hg38",
             gene_list="refgene",
@@ -165,8 +165,8 @@ class TestMaxPredictionQuery(TestCase):
 
     def test_max_count(self):
         expected_sql = COUNT_QUERY
-        expected_params = ["hg38", "refgene", "E2F4", "250", "150", "150", "250",
-                           "refgene", "E2F4", "250", "150", "150", "250"]
+        expected_params = ["hg38", "refgene", "E2F4", "150", "250", "250", "150",
+                           "refgene", "E2F4", "150", "250", "250", "150"]
         query = MaxPredictionQuery(
             schema="hg38",
             gene_list="refgene",

--- a/tests/test_predictionquery.py
+++ b/tests/test_predictionquery.py
@@ -59,10 +59,11 @@ end
 group by gene_id
 ) as foo"""
 
+
 class TestPredictionQuery(TestCase):
     def test_filter_with_limit(self):
         expected_sql = GENE_LIST_FILTER_WITH_LIMIT
-        expected_params = ["hg38", "knowngene", "E2F4", "250", "150", "150", "250", "100", "200"]
+        expected_params = ["hg38", "knowngene", "E2F4", "150", "250", "250", "150", "100", "200"]
         query = PredictionQuery(
             schema="hg38",
             gene_list="knowngene",
@@ -78,7 +79,7 @@ class TestPredictionQuery(TestCase):
 
     def test_filter(self):
         expected_sql = GENE_LIST_FILTER
-        expected_params = ["hg38", "knowngene", "E2F4", "250", "150", "150", "250"]
+        expected_params = ["hg38", "knowngene", "E2F4", "150", "250", "250", "150"]
         query = PredictionQuery(
             schema="hg38",
             gene_list="knowngene",
@@ -93,7 +94,7 @@ class TestPredictionQuery(TestCase):
 
     def test_count(self):
         expected_sql = COUNT_QUERY
-        expected_params = ["hg38", "knowngene", "E2F4", "250", "150", "150", "250"]
+        expected_params = ["hg38", "knowngene", "E2F4", "150", "250", "250", "150"]
         query = PredictionQuery(
             schema="hg38",
             gene_list="knowngene",


### PR DESCRIPTION
I think this was broken by 10ebd99412410abc572e14e447d4f94d44c0c251.
I changed the function that was run and didn't update the parameter position changes.