### PR TITLE
Change about content per Raluca email

### DIFF
--- a/portal/src/app/about/AboutContent.jsx
+++ b/portal/src/app/about/AboutContent.jsx
@@ -42,7 +42,10 @@ class AboutContent extends React.Component {
                     </a>, or directly in the iMADS
                     web application, using the graphical interface. Users can explore predictions around transcription
                     start sites (TSSs) of gene, using preloaded or custom gene lists, as well as custom lists of
-                    genomic coordinates.
+                    genomic coordinates. When using preloaded gene lists, only the genes/transcripts with predicted
+                    binding sites in the selected interval will be shown. When using custom gene lists, all
+                    genes/transcripts will be shown, regardless of whether or not they contain predicted binding
+                    sites in the selected interval.
                 </p>
             </div>
             <div>


### PR DESCRIPTION
Adds explanation about how the differences between how preloaded gene lists and the custom gene/range lists work. 

Custom gene/range lists include genes/ranges where there are no predictions.  The preloaded gene lists only show genes where there are predictions. Preloaded gene lists would result in many empty pages for typical upstream/downstream values if it functioned liked custom gene/range lists.