### PR TITLE
More binding site changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ADD ./third_party/linux.x86_64/bigBedToBed /usr/local/bin/bigBedToBed
 RUN ["chmod", "755", "/usr/local/bin/bigBedToBed"]
 
 # Install global dependencies
-RUN npm install webpack -g
+RUN npm install webpack@1.12.14 -g
 RUN ["pip", "install", "gunicorn"]
 
 # Install project dependencies - dependency files are added independently so that

--- a/portal/package.json
+++ b/portal/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "babel-core": "^6.17.0",    
+    "babel-core": "^6.17.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-class-properties": "^6.11.5",
     "babel-polyfill": "^6.7.4",
@@ -30,6 +30,7 @@
     "webpack": "^1.12.14"
   },
   "devDependencies": {
-    "chai": "^3.5.0"
+    "chai": "^3.5.0",
+    "webpack-cli": "^2.0.10"
   }
 }

--- a/portal/package.json
+++ b/portal/package.json
@@ -27,10 +27,9 @@
     "react-router": "^2.0.0",
     "react-tap-event-plugin": "^0.2.2",
     "style-loader": "^0.13.1",
-    "webpack": "^1.12.14"
+    "webpack": "1.12.14"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "webpack-cli": "^2.0.10"
+    "chai": "^3.5.0"
   }
 }

--- a/portal/src/app/about/AboutContent.jsx
+++ b/portal/src/app/about/AboutContent.jsx
@@ -98,11 +98,6 @@ class AboutContent extends React.Component {
                 </ul>
             </div>
             <div>
-                <h5 className="AboutContent_group_label">CONTACT</h5>
-                <p  className="AboutContent_paragraph">If you have any questions, want to provide feedback, or report any bugs,
-                    please send us an email at <a href="mailto:imads@duke.edu">imads@duke.edu</a></p>
-            </div>
-            <div>
                 <h5 className="AboutContent_group_label">CITATION</h5>
                 <p  className="AboutContent_paragraph">“Integrative modeling of differential DNA-binding specificity among paralogous transcription factors”.
                     Ning Shen, Jingkang Zhao, Josh Schipper, Tristan Bepler, Dan Leehr, John Bradley, John Horton,

--- a/portal/src/app/common/ContactEmail.jsx
+++ b/portal/src/app/common/ContactEmail.jsx
@@ -3,11 +3,13 @@ require('./ContactEmail.css');
 
 export default class ContactEmail extends React.Component {
     render() {
-        let {email} = this.props;
+        let {email, message} = this.props;
         let mailto = 'mailto:' + email;
-        let message = 'Contact email: ';
-        return <footer className="ContactEmail_container">
+        if (!message) {
+            message = 'Contact email: ';
+        }
+        return <div className="ContactEmail_container">
             <span className="ContactEmail_text">{message}<a href={mailto}>{email}</a></span>
-        </footer>;
+        </div>;
     }
 }

--- a/portal/src/app/common/Page.jsx
+++ b/portal/src/app/common/Page.jsx
@@ -10,10 +10,13 @@ require('./Page.css');
 export default class Page extends React.Component {
     render() {
         let {nav_path, children} = this.props;
+        const contactMessage = 'For questions, feedback, or bugs, ' +
+            'send an email to ';
         return <div className="Page_container" >
             <div className="Page_content">
                 <NavBar selected={nav_path} />
                 {children}
+                <ContactEmail message={contactMessage} email="imads@duke.edu" />
             </div>
         </div>;
     }

--- a/portal/src/app/models/ColumnFormats.js
+++ b/portal/src/app/models/ColumnFormats.js
@@ -21,7 +21,7 @@ export function CustomRangeColumnFormats() {
     const standardLabel = 'Genomic region coordinates, Maximum iMADS score (One line per region)';
     const numericBindingSitesLabel = 'Genomic region coordinates, iMADS scores for all positions in region (One line per region)';
     const bindingSiteListLabel = 'Genomic region coordinates, Binding site coordinates, ' +
-        'Binding site iMADS score, Binding site >sequence (One line per site)';
+        'Binding site iMADS score, Binding site sequence (One line per site)';
     const formats = {};
     formats[COLUMN_FORMAT_STANDARD] = { label: standardLabel };
     formats[COLUMN_FORMAT_NUMERIC_BINDING_SITES] = { label: numericBindingSitesLabel };

--- a/portal/src/app/models/ColumnFormats.js
+++ b/portal/src/app/models/ColumnFormats.js
@@ -8,7 +8,7 @@ export function GeneNameColumnFormats() {
         '(One line per region)';
     const numericBindingSitesLabel = 'Name, ID, Genomic region coordinates, iMADS scores for all positions in region ' +
         '(One line per region)';
-    const bindingSiteListLabel = 'Name, ID, Binding site location, Binding site iMADS score, Binding site sequence ' +
+    const bindingSiteListLabel = 'Name, ID, Binding site coordinates, Binding site iMADS score, Binding site sequence ' +
         '(One line per site)';
     const formats = {};
     formats[COLUMN_FORMAT_STANDARD] = { label: standardLabel };

--- a/portal/src/app/models/ColumnFormats.js
+++ b/portal/src/app/models/ColumnFormats.js
@@ -4,10 +4,12 @@ export const COLUMN_FORMAT_BINDING_SITES_LIST = 'bindingSiteList';
 export const COLUMN_FORMAT_RAW_DATA = 'rawData';
 
 export function GeneNameColumnFormats() {
-    const standardLabel = 'Name, ID, Max iMADS score, Chromosome, Start, End';
-    const numericBindingSitesLabel = standardLabel + ', followed by all values';
-    const bindingSiteListLabel = 'Name, ID, Binding site location, Binding site score, Binding site sequence ' +
-        '(one line per binding site)';
+    const standardLabel = 'Name, ID, Genomic region coordinates, Maximum iMADS score ' +
+        '(One line per region)';
+    const numericBindingSitesLabel = 'Name, ID, Genomic region coordinates, iMADS scores for all positions in region ' +
+        '(One line per region)';
+    const bindingSiteListLabel = 'Name, ID, Binding site location, Binding site iMADS score, Binding site sequence ' +
+        '(One line per site)';
     const formats = {};
     formats[COLUMN_FORMAT_STANDARD] = { label: standardLabel };
     formats[COLUMN_FORMAT_NUMERIC_BINDING_SITES] = { label: numericBindingSitesLabel };
@@ -16,11 +18,10 @@ export function GeneNameColumnFormats() {
 }
 
 export function CustomRangeColumnFormats() {
-    const standardLabel = 'Chromosome, Start, End, Max iMADS score';
-    const numericBindingSitesLabel = standardLabel + ', followed by all values';
-    const bindingSiteListLabel = 'Chromosome, Start, End, ' +
-        'Binding site location, Binding site score, Binding site sequence ' +
-        '(one line per binding site)';
+    const standardLabel = 'Genomic region coordinates, Maximum iMADS score (One line per region)';
+    const numericBindingSitesLabel = 'Genomic region coordinates, iMADS scores for all positions in region (One line per region)';
+    const bindingSiteListLabel = 'Genomic region coordinates, Binding site coordinates, ' +
+        'Binding site iMADS score, Binding site >sequence (One line per site)';
     const formats = {};
     formats[COLUMN_FORMAT_STANDARD] = { label: standardLabel };
     formats[COLUMN_FORMAT_NUMERIC_BINDING_SITES] = { label: numericBindingSitesLabel };
@@ -29,9 +30,9 @@ export function CustomRangeColumnFormats() {
 }
 
 export function CustomDNAColumnFormats() {
-    const standardLabel = 'Name, Sequence, Max iMADS score';
-    const numericBindingSitesLabel = standardLabel + ', followed by all values';
-    const rawFormatLabel = 'Name, Start, Stop, iMADS score (BED Format)';
+    const standardLabel = 'Name, Sequence, Maximum iMADS score (One line per input sequence)';
+    const numericBindingSitesLabel = 'Name, Sequence, iMADS scores for all positions (One line per input sequence)';
+    const rawFormatLabel = 'Name, Start, Stop, iMADS score, Binding site sequence (BED format; one line per binding site)';
     const formats = {};
     formats[COLUMN_FORMAT_STANDARD] = { label: standardLabel };
     formats[COLUMN_FORMAT_NUMERIC_BINDING_SITES] = { label: numericBindingSitesLabel };

--- a/pred/webserver/csvgenerator.py
+++ b/pred/webserver/csvgenerator.py
@@ -57,7 +57,7 @@ class BaseRowFormat(object):
         return [
             prediction['commonName'],
             prediction['name'],
-            '{}:{}-{}'.format(prediction['chrom'], str(start), str(end)),
+            '{}:{}-{}'.format(prediction['chrom'], start, end),
             str(prediction['max']),
         ]
 
@@ -92,7 +92,7 @@ class BindingSiteListRowFormat(BaseRowFormat):
         super(BindingSiteListRowFormat, self).__init__(args)
         self.base_headers = ['Name', 'ID']
         self.dna_lookup = DNALookup(config, genome)
-        self.extra_headers = ['Binding site location', 'Binding site iMADS score', 'Binding site sequence']
+        self.extra_headers = ['Binding site coordinates', 'Binding site iMADS score', 'Binding site sequence']
 
     def make_base_values(self, prediction):
         return [
@@ -130,13 +130,11 @@ class CustomRangesRowFormat(BaseRowFormat):
     """
     def __init__(self, args):
         super(CustomRangesRowFormat, self).__init__(args)
-        self.base_headers = ['Chromosome', 'Start', 'End', 'Max']
+        self.base_headers = ['Genomic region coordinates', 'Maximum iMADS score']
 
     def make_base_values(self, prediction):
         return [
-            prediction['chrom'],
-            str(prediction['start']),
-            str(prediction['end']),
+            '{}:{}-{}'.format(prediction['chrom'], prediction['start'], prediction['end']),
             str(prediction['max'])
         ]
 
@@ -147,7 +145,7 @@ class CustomRangesWithValuesRowFormat(CustomRangesRowFormat):
     """
     def __init__(self, args):
         super(CustomRangesWithValuesRowFormat, self).__init__(args)
-        self.extra_headers = ['Values']
+        self.extra_headers = ['iMADS scores']
 
     def make_values(self, prediction):
         values = self.make_base_values(prediction)
@@ -165,13 +163,11 @@ class CustomRangesBindingLSiteListRowFormat(BindingSiteListRowFormat):
         :param args: SearchArgs: settings used to determine which RowFormat class to create
         """
         super(CustomRangesBindingLSiteListRowFormat, self).__init__(config, genome, args)
-        self.base_headers = ['Chromosome', 'Start', 'End']
+        self.base_headers = ['Genomic region coordinates']
 
     def make_base_values(self, prediction):
         return [
-            prediction['chrom'],
-            str(prediction['start']),
-            str(prediction['end']),
+            '{}:{}-{}'.format(prediction['chrom'], prediction['start'], prediction['end']),
         ]
 
 def make_row_format(config, genome, args):

--- a/pred/webserver/csvgenerator.py
+++ b/pred/webserver/csvgenerator.py
@@ -34,7 +34,7 @@ class BaseRowFormat(object):
     """
     def __init__(self, args):
         self.args = args
-        self.base_headers = ['Name', 'ID', 'Max', 'Chromosome', 'Start', 'End']
+        self.base_headers = ['Name', 'ID', 'Genomic region coordinates', 'Maximum iMADS score']
         self.extra_headers = []
 
     def get_headers(self):
@@ -57,10 +57,8 @@ class BaseRowFormat(object):
         return [
             prediction['commonName'],
             prediction['name'],
+            '{}:{}-{}'.format(prediction['chrom'], str(start), str(end)),
             str(prediction['max']),
-            prediction['chrom'],
-            str(start),
-            str(end)
         ]
 
 
@@ -70,6 +68,7 @@ class NumericColumnRowFormat(BaseRowFormat):
     """
     def __init__(self, args):
         super(NumericColumnRowFormat, self).__init__(args)
+        self.base_headers = ['Name', 'ID', 'Genomic region coordinates']
         up = args.get_upstream()
         down = args.get_downstream()
         self.size = up + down + 1
@@ -93,7 +92,7 @@ class BindingSiteListRowFormat(BaseRowFormat):
         super(BindingSiteListRowFormat, self).__init__(args)
         self.base_headers = ['Name', 'ID']
         self.dna_lookup = DNALookup(config, genome)
-        self.extra_headers = ['Binding site location', 'Binding site score', 'DNA Sequence']
+        self.extra_headers = ['Binding site location', 'Binding site iMADS score', 'Binding site sequence']
 
     def make_base_values(self, prediction):
         return [

--- a/tests/test_csvgenerator.py
+++ b/tests/test_csvgenerator.py
@@ -34,11 +34,11 @@ class RowGeneratorTests(TestCase):
         generator = make_row_generator(Mock(), Mock(), self.search_args)
         csv_lines = self.strip_list(generator.generate_rows(self.predictions))
         expected_data = [
-            'Name,ID,Max,Chromosome,Start,End',
-            'DDX11L1,uc001aaa.3; uc010nxq.1; uc010nxr.1,0.3301,chr1,11673,12073',
-            'WASH7P,uc009vjb.1,0.3603,chr1,29761,30161',
-            'LOC729737,uc021oeg.2,0.2582,chr1,140366,140766',
-            'JJ1924,jjbbjj.1,0,chr1,240366,240766'
+            'Name,ID,Genomic region coordinates,Maximum iMADS score',
+            'DDX11L1,uc001aaa.3; uc010nxq.1; uc010nxr.1,chr1:11673-12073,0.3301',
+            'WASH7P,uc009vjb.1,chr1:29761-30161,0.3603',
+            'LOC729737,uc021oeg.2,chr1:140366-140766,0.2582',
+            'JJ1924,jjbbjj.1,chr1:240366-240766,0'
         ]
         self.assertEqual(expected_data, csv_lines)
 
@@ -48,11 +48,11 @@ class RowGeneratorTests(TestCase):
         generator = make_row_generator(Mock(), Mock(), self.search_args)
         csv_lines = self.strip_list(generator.generate_rows(self.predictions))
         self.assertEqual(5, len(csv_lines))
-        self.assertStartsWith('Name,ID,Max,Chromosome,Start,End,-1000,-999,-998', csv_lines[0])
-        self.assertStartsWith('DDX11L1,uc001aaa.3; uc010nxq.1; uc010nxr.1,0.3301,chr1,11673,12073,', csv_lines[1])
-        self.assertStartsWith('WASH7P,uc009vjb.1,0.3603,chr1,29761,30161,0,0,', csv_lines[2])
-        self.assertStartsWith('LOC729737,uc021oeg.2,0.2582,chr1,140366,140766,0,0,', csv_lines[3])
-        self.assertStartsWith('JJ1924,jjbbjj.1,0,chr1,240366,240766,0,0,', csv_lines[4])
+        self.assertStartsWith('Name,ID,Genomic region coordinates,-1000,-999,-998', csv_lines[0])
+        self.assertStartsWith('DDX11L1,uc001aaa.3; uc010nxq.1; uc010nxr.1,chr1:11673-12073,0.3301,', csv_lines[1])
+        self.assertStartsWith('WASH7P,uc009vjb.1,chr1:29761-30161,0.3603,0,0,', csv_lines[2])
+        self.assertStartsWith('LOC729737,uc021oeg.2,chr1:140366-140766,0.2582,0,0,', csv_lines[3])
+        self.assertStartsWith('JJ1924,jjbbjj.1,chr1:240366-240766,0,0,0,', csv_lines[4])
 
     @patch('pred.webserver.csvgenerator.DNALookup')
     def test_make_predictions_csv_response_binding_site_list(self, mock_dna_lookup):
@@ -62,7 +62,7 @@ class RowGeneratorTests(TestCase):
         generator = make_row_generator(Mock(download_dir='/data'), 'hg38', self.search_args)
         csv_lines = self.strip_list(generator.generate_rows(self.predictions))
         self.assertEqual(6, len(csv_lines))
-        expected_header = 'Name,ID,Binding site location,Binding site score,DNA Sequence'
+        expected_header = 'Name,ID,Binding site coordinates,Binding site iMADS score,Binding site sequence'
         self.assertEqual(expected_header, csv_lines[0])
         dxx_line = 'DDX11L1,uc001aaa.3; uc010nxq.1; uc010nxr.1'
         self.assertEqual('{},chr1:11710-11730,0.3301,ACGGTTA'.format(dxx_line), csv_lines[1])
@@ -80,11 +80,11 @@ class RowGeneratorTests(TestCase):
         generator = make_row_generator(Mock(), Mock(), self.search_args)
         csv_lines = self.strip_list(generator.generate_rows(self.predictions))
         self.assertEqual(5, len(csv_lines))
-        self.assertEqual('Chromosome,Start,End,Max', csv_lines[0])
-        self.assertEqual('chr1,11673,12073,0.3301', csv_lines[1])
-        self.assertEqual('chr1,29761,30161,0.3603', csv_lines[2])
-        self.assertEqual('chr1,140366,140766,0.2582', csv_lines[3])
-        self.assertEqual('chr1,240366,240766,0', csv_lines[4])
+        self.assertEqual('Genomic region coordinates,Maximum iMADS score', csv_lines[0])
+        self.assertEqual('chr1:11673-12073,0.3301', csv_lines[1])
+        self.assertEqual('chr1:29761-30161,0.3603', csv_lines[2])
+        self.assertEqual('chr1:140366-140766,0.2582', csv_lines[3])
+        self.assertEqual('chr1:240366-240766,0', csv_lines[4])
 
     def test_make_predictions_csv_response_custom_range_list_include_all(self):
         self.search_args.args[SearchArgs.GENE_LIST] = CUSTOM_RANGES_LIST
@@ -93,11 +93,11 @@ class RowGeneratorTests(TestCase):
         generator = make_row_generator(Mock(), Mock(), self.search_args)
         csv_lines = self.strip_list(generator.generate_rows(self.predictions))
         self.assertEqual(5, len(csv_lines))
-        self.assertEqual('Chromosome,Start,End,Max,Values', csv_lines[0])
-        self.assertStartsWith('chr1,11673,12073,0.3301,0,0,', csv_lines[1])
-        self.assertStartsWith('chr1,29761,30161,0.3603,0,0,', csv_lines[2])
-        self.assertStartsWith('chr1,140366,140766,0.2582,0,0,', csv_lines[3])
-        self.assertStartsWith('chr1,240366,240766,0,0,', csv_lines[4])
+        self.assertEqual('Genomic region coordinates,Maximum iMADS score,iMADS scores', csv_lines[0])
+        self.assertStartsWith('chr1:11673-12073,0.3301,0,0,', csv_lines[1])
+        self.assertStartsWith('chr1:29761-30161,0.3603,0,0,', csv_lines[2])
+        self.assertStartsWith('chr1:140366-140766,0.2582,0,0,', csv_lines[3])
+        self.assertStartsWith('chr1:240366-240766,0,0,', csv_lines[4])
 
     @patch('pred.webserver.csvgenerator.DNALookup')
     def test_make_predictions_csv_response_custom_range_binding_site_list(self, mock_dna_lookup):
@@ -108,8 +108,8 @@ class RowGeneratorTests(TestCase):
         generator = make_row_generator(Mock(), Mock(), self.search_args)
         csv_lines = self.strip_list(generator.generate_rows(self.predictions))
         self.assertEqual(6, len(csv_lines))
-        self.assertEqual('Chromosome,Start,End,Binding site location,Binding site score,DNA Sequence', csv_lines[0])
-        self.assertEqual('chr1,11673,12073,chr1:11710-11730,0.3301,ACGGTTA', csv_lines[1])
-        self.assertEqual('chr1,11673,12073,chr1:11904-11924,0.2867,GGAAATT', csv_lines[2])
-        self.assertEqual('chr1,29761,30161,chr1:30018-30038,0.3603,TTAAGGG', csv_lines[3])
-        self.assertEqual('chr1,140366,140766,chr1:140628-140648,0.2582,ATATAT', csv_lines[4])
+        self.assertEqual('Genomic region coordinates,Binding site coordinates,Binding site iMADS score,Binding site sequence', csv_lines[0])
+        self.assertEqual('chr1:11673-12073,chr1:11710-11730,0.3301,ACGGTTA', csv_lines[1])
+        self.assertEqual('chr1:11673-12073,chr1:11904-11924,0.2867,GGAAATT', csv_lines[2])
+        self.assertEqual('chr1:29761-30161,chr1:30018-30038,0.3603,TTAAGGG', csv_lines[3])
+        self.assertEqual('chr1:140366-140766,chr1:140628-140648,0.2582,ATATAT', csv_lines[4])

--- a/webserver.py
+++ b/webserver.py
@@ -326,9 +326,11 @@ def download_file_response(filename, gen):
 
 
 def make_download_custom_result(separator, include_all, predictions):
-    headers = ['Name', 'Sequence', 'Max']
-    if include_all:
-        headers.append('Values')
+    headers = ['Name', 'Sequence']
+    if not include_all:
+        headers.append('Maximum iMADS score')
+    else:
+        headers.append('iMADS scores for all positions')
     yield separator.join(headers) + '\n'
     for prediction in predictions:
         items = [


### PR DESCRIPTION
Updates markup text and downloaded CSV/TSV files to format changes requested in #143 

Due to time constraints, this changeset does not include the binding site sequence to the BED download for custom predictions.