### PR TITLE
Add DNA sequence to binding site BED format

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -189,7 +189,7 @@ class TestWithPostgres(unittest.TestCase):
         if not skip_postgres_tests():
             TestWithPostgres.config = parse_config_from_dict(CONFIG_DATA)
             TestWithPostgres.config.dbconfig.host = "localhost"
-            TestWithPostgres.config.dbconfig.dbname = 'predtest'
+            TestWithPostgres.config.dbconfig.dbname = 'pred'
             TestWithPostgres.config.dbconfig.user = 'pred_user'
             run_sql_command(TestWithPostgres.config)
 


### PR DESCRIPTION
For custom predictions these changes add DNA sequence to BED file output as the 5th column.
Users upload these sequences and they are stored in the database.
We query the database pulling out the list and slice out the sequence associated with the binding site prediction.

Fixes #145