### PR TITLE
Adds BASE_IMAGE ARG for production Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN npm install --only=dev
 # Now add the rest of the application source and run webpack
 ADD . ${MYDIR}
 CMD bash
-RUN ./node_modules/.bin/webpack
+RUN ./node_modules/.bin/webpack -p
 
 WORKDIR ${MYDIR}
 CMD ["gunicorn", "--bind", "0.0.0.0:80", "--timeout", "180", "--log-level=debug", "webserver:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2.7.11
 EXPOSE 80
 ENV MYDIR /tfdnapredictions
-RUN curl -sL https://deb.nodesource.com/setup_7.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y nodejs
 
 # Install bigBedToBed

--- a/portal/package.json
+++ b/portal/package.json
@@ -28,7 +28,7 @@
     "react-tap-event-plugin": "^0.2.2",
     "style-loader": "^0.13.1",
     "webpack": "^4.2.0",
-    "webpack-cli": "^2.0.13"
+    "webpack-cli": "^3.1.1"
   },
   "devDependencies": {
     "chai": "^3.5.0"

--- a/portal/package.json
+++ b/portal/package.json
@@ -27,8 +27,8 @@
     "react-router": "^2.0.0",
     "react-tap-event-plugin": "^0.2.2",
     "style-loader": "^0.13.1",
-    "webpack": "^4.2.0",
-    "webpack-cli": "^3.1.1"
+    "webpack": "^4.25.1",
+    "webpack-cli": "^3.1.2"
   },
   "devDependencies": {
     "chai": "^3.5.0"

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=dukegcb/imads
 FROM ${BASE_IMAGE}
 LABEL maintainer="john.bradley@duke.edu"
 # apache2

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -1,5 +1,6 @@
-FROM dukegcb/imads
-MAINTAINER john.bradley@duke.edu
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+LABEL maintainer="john.bradley@duke.edu"
 # apache2
 RUN apt-get update \
   && apt-get install -y apache2 apache2-utils libapache2-mod-wsgi\

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ SQLAlchemy==1.0.11
 Flask==0.10.1
 psycopg2==2.7.3.2
 PyYAML==3.11
-requests==2.9.1
+requests==2.20.0
 Jinja2==2.8
 twobitreader==3.1.4
 biopython==1.66


### PR DESCRIPTION
This is to enable the docker build on demand via [gcb-ansible build_docker_image](https://github.com/Duke-GCB/gcb-ansible-roles/tree/master/build_docker_image).
We will continue to build the Docker images from this repo to promote reuse by others.

Additional Changes
- Updating to Nodejs 8 - version 7 is EOL.
- Update `requests` minor version to fix vulnerability.
- Adds `-p` to webpack to build production javascript
- updates webpack and webpack-cli to be compatible versions - [details](https://github.com/Duke-GCB/iMADS/pull/156/commits/003dda87a4f3f01830a8a78c55557f3493ed14db)
