### PR TITLE
Updates location for new models

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.6.8
       - image: circleci/postgres:9.6.2
         environment:
           POSTGRES_USER: pred_user
@@ -17,7 +17,7 @@ jobs:
             source venv/bin/activate
             pip install -r requirements.txt
             pip install -r devRequirements.txt
-            curl -sL https://deb.nodesource.com/setup_8.x | sudo  sudo -E bash -
+            curl -sL https://deb.nodesource.com/setup_8.x | bash -
             sudo apt-get install -y nodejs
             cd portal
             npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             source venv/bin/activate
             pip install -r requirements.txt
             pip install -r devRequirements.txt
-            curl -sL https://deb.nodesource.com/setup_8.x | bash -
+            curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
             sudo apt-get install -y nodejs
             cd portal
             npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6.8
 EXPOSE 80
 ENV MYDIR /tfdnapredictions
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -

--- a/imadsconf.yaml
+++ b/imadsconf.yaml
@@ -465,7 +465,7 @@ genome_data:
   trackhub_url:
   - predictions: http://trackhub.genome.duke.edu/gordanlab/tf-dna-binding-predictions/hub.txt
   - preferences: http://trackhub.genome.duke.edu/gordanlab/tf-dna-preferences/hub.txt
-model_base_url: https://swift.oit.duke.edu/v1/AUTH_gcb/gordan_models
+model_base_url: https://zenodo.org/record/3405516/files
 model_tracks_url_list:
-- https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks-predictions.yaml
-- https://raw.githubusercontent.com/Duke-GCB/TrackHubGenerator/master/yaml/tracks/tracks-preferences.yaml
+- https://zenodo.org/record/3405516/files/tracks-predictions.yaml
+- https://zenodo.org/record/3405516/files/tracks-preferences.yaml


### PR DESCRIPTION
- Changes config files to use zenodo urls for model data
- Specifies python 3.6.8 docker image to fix error where pip fails to install numpy with python 3.6.9.
- Removes extra `sudo` in circleci config