### PR TITLE
Disables default apache conf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             source venv/bin/activate
             pip install -r requirements.txt
             pip install -r devRequirements.txt
-            curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+            curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
             sudo apt-get install -y nodejs
             cd portal
             npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6.8
 EXPOSE 80
 ENV MYDIR /tfdnapredictions
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
 
 # Install bigBedToBed

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -15,6 +15,7 @@ RUN mod_wsgi-express install-module
 RUN ["pip", "install", "mod_wsgi"]
 
 # Configure Apache
+RUN a2dissite 000-default # disable default apache logging config
 ADD imads.conf /etc/apache2/sites-available/imads.conf
 RUN a2enmod ssl
 RUN a2ensite imads


### PR DESCRIPTION
Disables default apache config that causes container-incompatible logging.

Upgrades to node 10 to fix error in tests due to mocha yargs parser requirement.

Fixes #163 