### PR TITLE
Change default apache config log stdout/stderr

### DIFF
--- a/production/000-default.conf
+++ b/production/000-default.conf
@@ -1,0 +1,5 @@
+<VirtualHost *:80>
+    DocumentRoot /var/www/html
+    CustomLog /dev/stdout combined
+    ErrorLog /dev/stderr
+</VirtualHost>

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -15,7 +15,7 @@ RUN mod_wsgi-express install-module
 RUN ["pip", "install", "mod_wsgi"]
 
 # Configure Apache
-RUN a2dissite 000-default # disable default apache logging config
+ADD 000-default.conf /etc/apache2/sites-available/000-default.conf
 ADD imads.conf /etc/apache2/sites-available/imads.conf
 RUN a2enmod ssl
 RUN a2ensite imads


### PR DESCRIPTION
This is to prevent the /var/log/apache2 directory inside the `web` container from filling up.
When this happened the contain failed to restart after a maintenance reboot.

Fixes #163